### PR TITLE
add cleaner for APT package lists cache in /var/lib/apt/lists

### DIFF
--- a/cleaners/apt.xml
+++ b/cleaners/apt.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2014 Andrew Ziem
+    Copyright (C) 2014 Andrew Ziem, nodiscc
     http://bleachbit.sourceforge.net
 
     This program is free software: you can redistribute it and/or modify
@@ -39,5 +39,10 @@
     <label translate="false">autoremove</label>
     <description>Delete obsolete files</description>
     <action command="apt.autoremove"/>
+  </option>
+  <option id="package-lists">
+    <label translate="false">Package lists</label>
+    <description>Delete the cached package lists</description>
+    <action command="delete" search="walk.all" path="/var/lib/apt/lists/"/>
   </option>
 </cleaner>


### PR DESCRIPTION
fixes https://github.com/az0/cleanerml/issues/24

I did not want to add a new cleaner for APT in https://github.com/az0/cleanerml, as the cleaner `<id>` must be unique, so it ended up with 2 `APT` entries in bleachbit's interface. I just updated the existing apt.xml file.
