### PR TITLE
add cleaner for APT package lists

### DIFF
--- a/cleaners/apt.xml
+++ b/cleaners/apt.xml
@@ -2,7 +2,7 @@
 <!--
 
     BleachBit
-    Copyright (C) 2014 Andrew Ziem
+    Copyright (C) 2014 Andrew Ziem, nodiscc
     http://bleachbit.sourceforge.net
 
     This program is free software: you can redistribute it and/or modify
@@ -39,5 +39,10 @@
     <label translate="false">autoremove</label>
     <description>Delete obsolete files</description>
     <action command="apt.autoremove"/>
+  </option>
+  <option id="package-lists">
+    <label translate="true">Package lists</label>
+    <description>Delete the cached package lists</description>
+    <action command="delete" search="walk.all" path="/var/lib/apt/lists/"/>
   </option>
 </cleaner>


### PR DESCRIPTION
removes the locally cached package lists in /var/lib/apt/lists, fixes az0/cleanerml#24.
From https://en.wikipedia.org/wiki/Advanced_Packaging_Tool:

> /var/lib/apt/lists/: storage area for state information for each package resource specified in sources.list

This frees about 180MB on my system, and can solve errors in case some package lists are corrupted (`E: The package lists or status file could not be parsed or opened.`) or a lock file improperly left in place (`E: Could not get lock /var/lib/apt/lists/lock`)
