### PR TITLE
Updated Liferea cleaner

### DIFF
--- a/cleaners/liferea.xml
+++ b/cleaners/liferea.xml
@@ -22,6 +22,8 @@
 <cleaner id="liferea">
   <label>Liferea</label>
   <running type="exe">liferea-bin</running>
+  <!-- Newer Liferea releases do not have a "liferea" wrapper anymore. Just a binary -->
+  <running type="exe">liferea</running>
   <option id="cache">
     <label>Cache</label>
     <description>Delete the cache</description>


### PR DESCRIPTION
Updating the Liferea cleaner to match recent release line 1.8 and 1.10 (since 1.10 switch to XDG paths).

Note: I'm maintainer of Liferea.
