### PR TITLE
Passwords deletion functionality

### DIFF
--- a/cleaners/opera.xml
+++ b/cleaners/opera.xml
@@ -67,6 +67,12 @@
     <action command="delete" search="file" path="$appdata\Opera\Opera\profile\download.dat"/>
     <action command="delete" search="file" path="~/.opera/download.dat"/>
   </option>
+  <option id="passwords">
+    <label>Passwords</label>
+    <warning>This will delete all of your saved passwords in Opera</warning>
+    <description>Delete all of your saved passwords in Opera.</description>
+    <action command="delete" search="file" path="~/.opera/wand.dat"/>
+  </option>
   <option id="search_history">
     <label>Search history</label>
     <description>Delete the search history</description>


### PR DESCRIPTION
Added passwords (wand.dat) file path for GNU+Linux. However, I noticed that the Passwords option was not appearing in my copy of BB for some odd reason. Anyone else experience this?
