### PR TITLE
Octave cleanup

### DIFF
--- a/cleaners/octave.xml
+++ b/cleaners/octave.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+
     BleachBit
     Copyright (C) 2008-2017 Andrew Ziem
     https://www.bleachbit.org
@@ -16,6 +17,7 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 -->
 <cleaner id="octave">
   <label>Octave</label>

--- a/cleaners/octave.xml
+++ b/cleaners/octave.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
     BleachBit
     Copyright (C) 2008-2017 Andrew Ziem
     https://www.bleachbit.org
@@ -17,10 +16,7 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 -->
-<!-- verified with Octave version 3.6.2 on Ubuntu 12.10 -->
-<!-- verified with Octave version 3.6.2 on Windows XP -->
 <cleaner id="octave">
   <label>Octave</label>
   <option id="history">


### PR DESCRIPTION
- Removed comments. Ubuntu version 12 will be obsolete in BleachBit, soon and version 3.x is 5 years old.