### PR TITLE
Sqlite cleanup

### DIFF
--- a/cleaners/sqlite3.xml
+++ b/cleaners/sqlite3.xml
@@ -19,7 +19,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<!-- verified with SQLite version 3.7.13 on Ubuntu 12.10 -->
 <cleaner id="sqlite3" os="linux">
   <label>sqlite3</label>
   <option id="history">


### PR DESCRIPTION
- Removed comment. Too old of version for testing and Ubuntu version 12 will be obsolete in BleachBit, soon.