### PR TITLE
Reduce Windows installation size by ~12M

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,8 @@ install:
   - '%PYTHON_HOME%/Scripts/pip.exe install py2exe_py2'
   - ps: if (-not (Test-Path pygtk-all-in-one-2.24.2.win32-py2.7.msi)) { Start-FileDownload "http://ftp.gnome.org/pub/GNOME/binaries/win32/pygtk/2.24/pygtk-all-in-one-2.24.2.win32-py2.7.msi" }
   - 'msiexec /i pygtk-all-in-one-2.24.2.win32-py2.7.msi /qn /norestart /log pygtk-install.log TARGETDIR=C:\Python27 ALLUSERS=1'
-  - ps: if (-not (Test-Path upx392w.zip)) { Start-FileDownload "http://github.com/upx/upx/releases/download/v3.92/upx392w.zip" }
-  - '%SZ_EXE% x upx392w.zip'
+  - ps: if (-not (Test-Path upx393w.zip)) { Start-FileDownload "http://github.com/upx/upx/releases/download/v3.93/upx393w.zip" }
+  - '%SZ_EXE% x upx393w.zip'
   - ps: if (-not (Test-Path gettext0.19.8.1-iconv1.14-static-32.zip)) { Start-FileDownload "http://github.com/mlocati/gettext-iconv-windows/releases/download/v0.19.8.1-v1.14/gettext0.19.8.1-iconv1.14-static-32.zip" }
   - '%SZ_EXE% x gettext0.19.8.1-iconv1.14-static-32.zip -ogettext'
   - 'set PATH=%PATH%;%cd%\gettext\bin;C:\MinGW\bin;'
@@ -36,7 +36,7 @@ build_script:
 
 cache:
   - pygtk-all-in-one-2.24.2.win32-py2.7.msi
-  - upx392w.zip
+  - upx393w.zip
   - gettext0.19.8.1-iconv1.14-static-32.zip
 
 test_script:

--- a/windows/setup_py2exe.py
+++ b/windows/setup_py2exe.py
@@ -62,7 +62,7 @@ SZ_OPTS = '-tzip -mm=Deflate -mfb=258 -mpass=7 -bso0 -bsp0'  # best compression
 if fast:
     # fast compression
     SZ_OPTS = '-tzip -mx=1 -bso0 -bsp0'
-UPX_EXE = ROOT_DIR + '\\upx392w\\upx.exe'
+UPX_EXE = ROOT_DIR + '\\upx393w\\upx.exe'
 UPX_OPTS = '--best --crp-ms=999999 --nrv2e'
 
 
@@ -241,8 +241,11 @@ def delete_unnecessary():
     delete_paths = [
         r'_win32sysloader.pyd',
         r'bz2.pyd',
+        r'etc\bash_completion.d',
+        r'lib\GNU.Gettext.dll',
         r'lib\gdk-pixbuf-2.0',
         r'lib\glib-2.0',
+        r'lib\gtk-2.0\include',
         r'lib\pkgconfig',
         r'perfmon.pyd',
         r'select.pyd',
@@ -362,10 +365,11 @@ def upx():
     logger.info('Compressing executables')
     if os.path.exists(UPX_EXE):
         upx_patterns = [
+            r'*.dll',
             r'*.exe',
-            r'freetype6.dll',
-            r'intl.dll',
-            r'lib\gtk-2.0\2.10.0\engines\lib*.dll',
+            r'*.pyd',
+            r'lib\gtk-2.0\2.10.0\engines\*.dll',
+            r'lib\gtk-2.0\modules\*.dll',
         ]
         upx_files = []
         for pattern in upx_patterns:


### PR DESCRIPTION
- Switch to UPX 3.93: this allows to compress all *.pyd and *.dll
(see https://github.com/upx/upx/issues/42).
This saves about 12M of uncompressed distribution size.
- Remove the following unused files:
	- etc\bash_completion.d
	- lib\GNU.Gettext.dll (.Net library)
	- lib\gtk2.0\include