### PR TITLE
Improve unit tests

### DIFF
--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -660,7 +660,7 @@ def wipe_contents(path, truncate=True):
                 with open(path, 'wb') as f:
                     truncate_f(f)
             except IOError as e2:
-                if errno.EACCESS == e.errno:
+                if errno.EACCES == e2.errno:
                     # Common when the file is locked
                     # Errno 13 Permission Denied
                     pass

--- a/tests/TestAction.py
+++ b/tests/TestAction.py
@@ -90,7 +90,7 @@ def dir_is_empty(dirname):
     return not os.listdir(dirname)
 
 
-class ActionTestCase(unittest.TestCase, common.AssertFile):
+class ActionTestCase(common.BleachbitTestCase):
 
     """Test cases for Action"""
 

--- a/tests/TestAction.py
+++ b/tests/TestAction.py
@@ -107,8 +107,7 @@ class ActionTestCase(common.BleachbitTestCase):
                 provider = actionplugin(action_node)
         self.assertNotEqual(provider, None)
         for cmd in provider.get_commands():
-            self.assert_(
-                isinstance(cmd, (Command.Delete, Command.Ini, Command.Json, Command.Function)))
+            self.assertIsInstance(cmd, (Command.Delete, Command.Ini, Command.Json, Command.Function))
             if 'process' != command:
                 # process does not have a filename
                 self.assertLExists(filename)
@@ -131,8 +130,7 @@ class ActionTestCase(common.BleachbitTestCase):
             else:
                 raise RuntimeError("Unknown command '%s'" % command)
         if 'walk.all' == search:
-            self.assert_(dir_is_empty(filename),
-                         'directory not empty after walk.all: %s' % filename)
+            self.assertTrue(dir_is_empty(filename), 'directory not empty after walk.all: %s' % filename)
 
     def test_delete(self):
         """Unit test for class Delete"""
@@ -233,49 +231,48 @@ class ActionTestCase(common.BleachbitTestCase):
         # should match three files using no regexes
         action_str = u'<action command="delete" search="glob" path="/tmp/foo*" />'
         results = _action_str_to_results(action_str)
-        self.assert_(3 == len(results))
+        self.assertEqual(len(results), 3)
 
         # should match second file using positive regex
         action_str = u'<action command="delete" search="glob" path="/tmp/foo*" regex="^foo2$"/>'
         results = _action_str_to_results(action_str)
-        self.assert_(1 == len(results))
+        self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['path'], '/tmp/foo2')
 
         # On Windows should be case insensitive
         action_str = u'<action command="delete" search="glob" path="/tmp/foo*" regex="^FOO2$"/>'
         results = _action_str_to_results(action_str)
         if 'nt' == os.name:
-            self.assert_(1 == len(results))
+            self.assertEqual(len(results), 1)
             self.assertEqual(results[0]['path'], '/tmp/foo2')
         else:
-            self.assert_(0 == len(results))
+            self.assertEqual(len(results), 0)
 
         # should match second file using negative regex
         action_str = u'<action command="delete" search="glob" path="/tmp/foo*" nregex="^(foo1|bar1)$"/>'
         results = _action_str_to_results(action_str)
-        self.assert_(1 == len(results))
+        self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['path'], '/tmp/foo2')
 
         # should match second file using both regexes
         action_str = u'<action command="delete" search="glob" path="/tmp/foo*" regex="^f" nregex="1$"/>'
         results = _action_str_to_results(action_str)
-        self.assert_(1 == len(results))
+        self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['path'], '/tmp/foo2')
 
         # should match nothing using positive regex
         action_str = u'<action command="delete" search="glob" path="/tmp/foo*" regex="^bar$"/>'
         results = _action_str_to_results(action_str)
-        self.assert_(0 == len(results))
+        self.assertEqual(len(results), 0)
 
         # should match nothing using negative regex
         action_str = u'<action command="delete" search="glob" path="/tmp/foo*" nregex="."/>'
         results = _action_str_to_results(action_str)
-        self.assert_(0 == len(results))
+        self.assertEqual(len(results), 0)
 
         # should give an error
         action_str = u'<action command="delete" search="invalid" path="/tmp/foo*" regex="^bar$"/>'
-        self.assertRaises(
-            RuntimeError, lambda: _action_str_to_results(action_str))
+        self.assertRaises(RuntimeError, lambda: _action_str_to_results(action_str))
 
         # clean up
         glob.iglob = _iglob
@@ -291,18 +288,18 @@ class ActionTestCase(common.BleachbitTestCase):
         # should match three files using no regexes
         action_str = u'<action command="delete" search="glob" path="/tmp/foo*" />'
         results = _action_str_to_results(action_str)
-        self.assert_(3 == len(results))
+        self.assertEqual(len(results), 3)
 
         # should match two files using wholeregex
         action_str = u'<action command="delete" search="glob" path="/tmp/foo*" wholeregex="^/tmp/foo.*$"/>'
         results = _action_str_to_results(action_str)
-        self.assert_(2 == len(results))
+        self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['path'], '/tmp/foo1')
 
         # should match third file using nwholeregex
         action_str = u'<action command="delete" search="glob" path="/tmp/foo*" nwholeregex="^/tmp/foo.*$"/>'
         results = _action_str_to_results(action_str)
-        self.assert_(1 == len(results))
+        self.assertEqual(len(results), 1)
         self.assertEqual(results[0]['path'], '/tmp/bar1')
 
         # clean up
@@ -362,19 +359,17 @@ class ActionTestCase(common.BleachbitTestCase):
 
     def test_walk_files(self):
         """Unit test for walk.files"""
-        if 'posix' == os.name:
-            path = '/var'
-        elif 'nt' == os.name:
-            path = '$WINDIR\\system32'
-        action_str = u'<action command="delete" search="walk.files" path="%s" />' % path
+        paths = {'posix': '/var', 'nt': '$WINDIR\\system32'}
+
+        action_str = u'<action command="delete" search="walk.files" path="%s" />' % paths[os.name]
         results = 0
         for cmd in _action_str_to_commands(action_str):
             result = cmd.execute(False).next()
             common.validate_result(self, result)
             path = result['path']
-            self.assert_(not os.path.isdir(path), "%s is a directory" % path)
+            self.assertFalse(os.path.isdir(path), "%s is a directory" % path)
             results += 1
-        self.assert_(results > 0)
+        self.assertGreater(results, 0)
 
 
 def suite():

--- a/tests/TestAction.py
+++ b/tests/TestAction.py
@@ -146,9 +146,7 @@ class ActionTestCase(common.BleachbitTestCase):
         for path in paths:
             for mode in ('delete', 'truncate', 'delete_forward'):
                 expanded = expanduser(expandvars(path))
-                (fd, filename) = tempfile.mkstemp(
-                    dir=expanded, prefix='bleachbit-action-delete')
-                os.close(fd)
+                filename = self.mkstemp(dir=expanded, prefix='bleachbit-action-delete')
                 command = mode
                 if 'delete_forward' == mode:
                     # forward slash needs to be normalized on Windows
@@ -166,19 +164,16 @@ class ActionTestCase(common.BleachbitTestCase):
 
     def test_delete_special_filenames(self):
         """Unit test for deleting special filenames"""
-        dirname = tempfile.mkdtemp(prefix='bleachbit-action-delete-special')
         tests = [
             'normal',
             'space in name',
             'sigil$should-not-be-expanded',
         ]
         for test in tests:
-            pathname = os.path.join(dirname, test)
-            common.touch_file(pathname)
+            pathname = self.write_file(test)
             action_str = u'<action command="delete" search="file" path="%s" />' % pathname
             self._test_action_str(action_str)
             self.assertNotExists(pathname)
-        os.rmdir(dirname)
 
     def test_ini(self):
         """Unit test for class Ini"""
@@ -207,10 +202,7 @@ class ActionTestCase(common.BleachbitTestCase):
 
     def test_process(self):
         """Unit test for process action"""
-        if 'nt' == os.name:
-            cmd = 'cmd.exe /c dir'
-        if 'posix' == os.name:
-            cmd = 'dir'
+        cmds = {'nt': 'cmd.exe /c dir', 'posix': 'dir'}
         tests = [u'<action command="process" cmd="%s" />',
                  u'<action command="process" wait="false" cmd="%s" />',
                  u'<action command="process" wait="f" cmd="%s" />',
@@ -219,7 +211,7 @@ class ActionTestCase(common.BleachbitTestCase):
                  ]
 
         for test in tests:
-            self._test_action_str(test % cmd)
+            self._test_action_str(test % cmds[os.name])
 
     def test_regex(self):
         """Unit test for regex option"""
@@ -308,7 +300,7 @@ class ActionTestCase(common.BleachbitTestCase):
 
     def test_type(self):
         """Unit test for type attribute"""
-        dirname = tempfile.mkdtemp(prefix='bleachbit-action-type')
+        dirname = self.mkdtemp(prefix='bleachbit-action-type')
         filename = os.path.join(dirname, 'file')
 
         # this should not delete anything
@@ -340,7 +332,7 @@ class ActionTestCase(common.BleachbitTestCase):
 
     def test_walk_all(self):
         """Unit test for walk.all"""
-        dirname = tempfile.mkdtemp(prefix='bleachbit-walk-all')
+        dirname = self.mkdtemp(prefix='bleachbit-walk-all')
 
         # this sub-directory should be deleted
         subdir = os.path.join(dirname, 'sub')

--- a/tests/TestCLI.py
+++ b/tests/TestCLI.py
@@ -38,7 +38,6 @@ import unittest
 
 
 class CLITestCase(common.BleachbitTestCase):
-
     """Test case for module CLI"""
 
     def setUp(self):
@@ -82,16 +81,13 @@ class CLITestCase(common.BleachbitTestCase):
     def test_encoding(self):
         """Unit test for encoding"""
 
-        (fd, filename) = tempfile.mkstemp(
-            prefix='bleachbit-test-cli-encoding-\xe4\xf6\xfc~', dir='/tmp')
-        os.close(fd)
+        filename = self.write_file('/tmp/bleachbit-test-cli-encoding-\xe4\xf6\xfc~')
         # not assertExists because it doesn't cope with invalid encodings
         self.assertTrue(os.path.exists(filename))
 
         env = copy.deepcopy(os.environ)
         env['LANG'] = 'en_US'  # not UTF-8
-        module = 'bleachbit.CLI'
-        args = [sys.executable, '-m', module, '-p', 'system.tmp']
+        args = [sys.executable, '-m', 'bleachbit.CLI', '-p', 'system.tmp']
         # If Python pipes stdout to file or devnull, the test may give
         # a false negative.  It must print stdout to terminal.
         self._test_preview(args, stdout=True, env=env)
@@ -104,8 +100,7 @@ class CLITestCase(common.BleachbitTestCase):
         lang = os.environ['LANG']
         os.environ['LANG'] = 'blahfoo'
         # tests are run from the parent directory
-        module = 'bleachbit.CLI'
-        args = [sys.executable, '-m', module, '--version']
+        args = [sys.executable, '-m', 'bleachbit.CLI', '--version']
         output = run_external(args)
         self.assertNotEqual(output[1].find('Copyright'), -1, str(output))
         os.environ['LANG'] = lang
@@ -127,8 +122,7 @@ class CLITestCase(common.BleachbitTestCase):
 
     def test_delete(self):
         """Unit test for --delete option"""
-        (fd, filename) = tempfile.mkstemp(prefix='bleachbit-test-cli-delete')
-        os.close(fd)
+        filename = self.mkstemp(prefix='bleachbit-test-cli-delete')
         if 'nt' == os.name:
             import win32api
             filename = os.path.normcase(filename)

--- a/tests/TestCLI.py
+++ b/tests/TestCLI.py
@@ -37,8 +37,7 @@ import tempfile
 import unittest
 
 
-
-class CLITestCase(unittest.TestCase):
+class CLITestCase(common.BleachbitTestCase):
 
     """Test case for module CLI"""
 
@@ -170,11 +169,3 @@ class CLITestCase(unittest.TestCase):
                 args = [sys.executable, '-m', 'bleachbit.CLI', '--shred', filename]
                 output = run_external(args, stdout=open(os.devnull, 'w'))
                 self.assert_(not os.path.exists(filename))
-
-
-def suite():
-    return unittest.makeSuite(CLITestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestCleaner.py
+++ b/tests/TestCleaner.py
@@ -32,11 +32,10 @@ from bleachbit.Cleaner import *
 from tests import common
 
 import logging
-import tempfile
-import unittest
 from xml.dom.minidom import parseString
 
 logger = logging.getLogger('bleachbit')
+
 
 def action_to_cleaner(action_str):
     """Given an action XML fragment, return a cleaner"""
@@ -69,25 +68,20 @@ class CleanerTestCase(common.BleachbitTestCase):
         """Unit test for Cleaner.add_action()"""
         self.actions = []
         if 'nt' == os.name:
-            self.actions.append(
-                '<action command="delete" search="file" path="$WINDIR\\explorer.exe"/>')
-            self.actions.append(
-                '<action command="delete" search="glob" path="$WINDIR\\system32\\*.dll"/>')
-            self.actions.append(
-                '<action command="delete" search="walk.files" path="$WINDIR\\system32\\"/>')
-            self.actions.append(
-                '<action command="delete" search="walk.all" path="$WINDIR\\system32\\"/>')
+            self.actions += [
+                '<action command="delete" search="file" path="$WINDIR\\explorer.exe"/>',
+                '<action command="delete" search="glob" path="$WINDIR\\system32\\*.dll"/>',
+                '<action command="delete" search="walk.files" path="$WINDIR\\system32\\"/>',
+                '<action command="delete" search="walk.all" path="$WINDIR\\system32\\"/>']
         elif 'posix' == os.name:
             print(__file__)
-            self.actions.append(
-                '<action command="delete" search="file" path="%s"/>' % __file__)
-            self.actions.append(
-                '<action command="delete" search="glob" path="/bin/*sh"/>')
-            self.actions.append(
-                '<action command="delete" search="walk.files" path="/bin/"/>')
-            self.actions.append(
-                '<action command="delete" search="walk.all" path="/var/log/"/>')
-
+            self.actions += [
+                '<action command="delete" search="file" path="%s"/>' % __file__,
+                '<action command="delete" search="glob" path="/bin/*sh"/>',
+                '<action command="delete" search="walk.files" path="/bin/"/>',
+                '<action command="delete" search="walk.all" path="/var/log/"/>']
+        else:
+            raise AssertionError('Unknown OS.')
         self.assertGreater(len(self.actions), 0)
 
         for action_str in self.actions:
@@ -115,27 +109,23 @@ class CleanerTestCase(common.BleachbitTestCase):
 
     def test_create_simple_cleaner(self):
         """Unit test for method create_simple_cleaner"""
-        dirname = tempfile.mkdtemp(
-            prefix='bleachbit-test-create-simple-cleaner')
+        dirname = self.mkdtemp(prefix='bleachbit-test-create-simple-cleaner')
         filename1 = os.path.join(dirname, '1')
         common.touch_file(filename1)
         # test Cyrillic for https://bugs.launchpad.net/bleachbit/+bug/1541808
         filename2 = os.path.join(dirname, u'чистый')
         common.touch_file(filename2)
-        self.assertExists(filename1)
-        self.assertExists(filename2)
-        cleaner = create_simple_cleaner([filename1, filename2, dirname])
+        targets = [filename1, filename2, dirname]
+        cleaner = create_simple_cleaner(targets)
         for cmd in cleaner.get_commands('files'):
             # preview
             for result in cmd.execute(False):
                 common.validate_result(self, result)
             # delete
-            for result in cmd.execute(True):
-                pass
+            list(cmd.execute(True))
 
-        self.assertNotExists(filename1)
-        self.assertNotExists(filename2)
-        self.assertNotExists(dirname)
+        for target in targets:
+            self.assertNotExists(target)
 
     def test_get_name(self):
         for key in sorted(backends):

--- a/tests/TestCleaner.py
+++ b/tests/TestCleaner.py
@@ -88,7 +88,7 @@ class CleanerTestCase(common.BleachbitTestCase):
             self.actions.append(
                 '<action command="delete" search="walk.all" path="/var/log/"/>')
 
-        self.assert_(len(self.actions) > 0)
+        self.assertGreater(len(self.actions), 0)
 
         for action_str in self.actions:
             cleaner = action_to_cleaner(action_str)
@@ -97,22 +97,21 @@ class CleanerTestCase(common.BleachbitTestCase):
                 for result in cmd.execute(False):
                     self.assertEqual(result['n_deleted'], 1)
                     pathname = result['path']
-                    self.assert_(os.path.lexists(pathname),
-                                 "Does not exist: '%s'" % pathname)
+                    self.assertLExists(pathname, "Does not exist: '%s'" % pathname)
                     count += 1
                     common.validate_result(self, result)
-            self.assert_(count > 0, "No files found for %s" % action_str)
+            self.assertGreater(count, 0, "No files found for %s" % action_str)
         # should yield nothing
         cleaner.add_option('option2', 'name2', 'description2')
         for cmd in cleaner.get_commands('option2'):
             print(cmd)
-            self.assert_(False, 'option2 should yield nothing')
+            raise AssertionError('option2 should yield nothing')
         # should fail
         self.assertRaises(RuntimeError, cleaner.get_commands('option3').next)
 
     def test_auto_hide(self):
         for key in sorted(backends):
-            self.assert_(isinstance(backends[key].auto_hide(), bool))
+            self.assertIsInstance(backends[key].auto_hide(), bool)
 
     def test_create_simple_cleaner(self):
         """Unit test for method create_simple_cleaner"""
@@ -123,8 +122,8 @@ class CleanerTestCase(common.BleachbitTestCase):
         # test Cyrillic for https://bugs.launchpad.net/bleachbit/+bug/1541808
         filename2 = os.path.join(dirname, u'чистый')
         common.touch_file(filename2)
-        self.assert_(os.path.exists(filename1))
-        self.assert_(os.path.exists(filename2))
+        self.assertExists(filename1)
+        self.assertExists(filename2)
         cleaner = create_simple_cleaner([filename1, filename2, dirname])
         for cmd in cleaner.get_commands('files'):
             # preview
@@ -134,28 +133,27 @@ class CleanerTestCase(common.BleachbitTestCase):
             for result in cmd.execute(True):
                 pass
 
-        self.assert_(not os.path.exists(filename1))
-        self.assert_(not os.path.exists(filename2))
-        self.assert_(not os.path.exists(dirname))
+        self.assertNotExists(filename1)
+        self.assertNotExists(filename2)
+        self.assertNotExists(dirname)
 
     def test_get_name(self):
         for key in sorted(backends):
-            self.assert_(isinstance(backends[key].get_name(), (str, unicode)))
+            self.assertIsString(backends[key].get_name())
 
     def test_get_description(self):
         for key in sorted(backends):
-            self.assert_(isinstance(key, (str, unicode)))
-            self.assert_(isinstance(backends[key], Cleaner))
+            self.assertIsString(key)
+            self.assertIsInstance(backends[key], Cleaner)
             desc = backends[key].get_description()
-            self.assert_(isinstance(desc, (str, unicode, type(None))),
-                         "description for '%s' is '%s'" % (key, desc))
+            if desc is not None:
+                self.assertIsString(desc, "description for '%s' is '%s'" % (key, desc))
 
     def test_get_options(self):
         for key in sorted(backends):
             for (test_id, name) in backends[key].get_options():
-                self.assert_(isinstance(test_id, (str, unicode)),
-                             '%s.%s is not a string' % (key, test_id))
-                self.assert_(isinstance(name, (str, unicode)))
+                self.assertIsString(test_id, '%s.%s is not a string' % (key, test_id))
+                self.assertIsString(name)
 
     def test_get_commands(self):
         for key in sorted(backends):
@@ -180,7 +178,7 @@ class CleanerTestCase(common.BleachbitTestCase):
         trash_paths = get_files('trash')
         tmp_paths = get_files('tmp')
         for tmp_path in tmp_paths:
-            self.assert_(tmp_path not in trash_paths)
+            self.assertNotIn(tmp_path, trash_paths)
 
     def test_no_files_exist(self):
         """Verify only existing files are returned"""
@@ -200,7 +198,7 @@ class CleanerTestCase(common.BleachbitTestCase):
                             break
                         msg = "Expected no files to be deleted but got '%s'" % str(
                             result)
-                        self.assert_(not isinstance(cmd, Command.Delete), msg)
+                        self.assertNotIsInstance(cmd, Command.Delete, msg)
                         common.validate_result(self, result)
         glob.iglob = _iglob
         os.path.exists = _exists

--- a/tests/TestCleaner.py
+++ b/tests/TestCleaner.py
@@ -63,7 +63,7 @@ def actions_to_cleaner(action_strs):
     return cleaner
 
 
-class CleanerTestCase(unittest.TestCase, common.AssertFile):
+class CleanerTestCase(common.BleachbitTestCase):
 
     def test_add_action(self):
         """Unit test for Cleaner.add_action()"""
@@ -234,10 +234,3 @@ class CleanerTestCase(unittest.TestCase, common.AssertFile):
         for test in tests:
             self.assertEqual(
                 backends['system'].whitelisted(test[0]), test[1], test[0])
-
-
-def suite():
-    return unittest.makeSuite(CleanerTestCase)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestCleanerML.py
+++ b/tests/TestCleanerML.py
@@ -21,18 +21,13 @@
 """
 Test cases for module CleanerML
 """
-
-
 from __future__ import absolute_import, print_function
 
 from tests import common
 from bleachbit.CleanerML import *
 
-import unittest
-
 
 class CleanerMLTestCase(common.BleachbitTestCase):
-
     """Test cases for CleanerML"""
 
     def test_CleanerML(self):
@@ -82,14 +77,10 @@ class CleanerMLTestCase(common.BleachbitTestCase):
         load_cleaners()
 
         # should catch exception with invalid XML
-        import tempfile
         pcd = bleachbit.personal_cleaners_dir
-        bleachbit.personal_cleaners_dir = tempfile.mkdtemp(
-            prefix='bleachbit-cleanerml-load')
-        fn_xml = os.path.join(bleachbit.personal_cleaners_dir, 'invalid.xml')
-        f = open(fn_xml, 'w')
-        f.write('<xml><broken>')
-        f.close()
+        bleachbit.personal_cleaners_dir = self.mkdtemp(prefix='bleachbit-cleanerml-load')
+        self.write_file(os.path.join(bleachbit.personal_cleaners_dir, 'invalid.xml'),
+                        contents='<xml><broken>')
         load_cleaners()
         import shutil
         shutil.rmtree(bleachbit.personal_cleaners_dir)

--- a/tests/TestCleanerML.py
+++ b/tests/TestCleanerML.py
@@ -41,8 +41,8 @@ class CleanerMLTestCase(common.BleachbitTestCase):
             os.chdir('tests')
         xmlcleaner = CleanerML("../doc/example_cleaner.xml")
 
-        self.assert_(isinstance(xmlcleaner, CleanerML))
-        self.assert_(isinstance(xmlcleaner.cleaner, Cleaner.Cleaner))
+        self.assertIsInstance(xmlcleaner, CleanerML)
+        self.assertIsInstance(xmlcleaner.cleaner, Cleaner.Cleaner)
 
         def run_all(really_delete):
             for (option_id, __name) in xmlcleaner.cleaner.get_options():
@@ -97,4 +97,4 @@ class CleanerMLTestCase(common.BleachbitTestCase):
 
     def test_pot_fragment(self):
         """Unit test for pot_fragment()"""
-        self.assert_(isinstance(pot_fragment("Foo", 'bar.xml'), str))
+        self.assertIsString(pot_fragment("Foo", 'bar.xml'))

--- a/tests/TestCleanerML.py
+++ b/tests/TestCleanerML.py
@@ -31,7 +31,7 @@ from bleachbit.CleanerML import *
 import unittest
 
 
-class CleanerMLTestCase(unittest.TestCase, common.AssertFile):
+class CleanerMLTestCase(common.BleachbitTestCase):
 
     """Test cases for CleanerML"""
 
@@ -98,11 +98,3 @@ class CleanerMLTestCase(unittest.TestCase, common.AssertFile):
     def test_pot_fragment(self):
         """Unit test for pot_fragment()"""
         self.assert_(isinstance(pot_fragment("Foo", 'bar.xml'), str))
-
-
-def suite():
-    return unittest.makeSuite(CleanerMLTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestCommand.py
+++ b/tests/TestCommand.py
@@ -29,10 +29,9 @@ from tests import common
 from bleachbit.Command import *
 
 import tempfile
-import unittest
 
 
-class CommandTestCase(unittest.TestCase):
+class CommandTestCase(common.BleachbitTestCase):
 
     """Test case for Command"""
 
@@ -80,11 +79,3 @@ class CommandTestCase(unittest.TestCase):
     def test_Shred(self):
         """Unit test for Shred"""
         self.test_Delete(Shred)
-
-
-def suite():
-    return unittest.makeSuite(CommandTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestCommand.py
+++ b/tests/TestCommand.py
@@ -41,20 +41,20 @@ class CommandTestCase(common.BleachbitTestCase):
         os.write(fd, "foo")
         os.close(fd)
         cmd = cls(path)
-        self.assert_(os.path.exists(path))
+        self.assertExists(path)
 
         # preview
         ret = cmd.execute(really_delete=False).next()
         s = str(cmd)
-        self.assert_(ret['size'] > 0)
+        self.assertGreater(ret['size'], 0)
         self.assertEqual(ret['path'], path)
-        self.assert_(os.path.exists(path))
+        self.assertExists(path)
 
         # delete
         ret = cmd.execute(really_delete=True).next()
-        self.assert_(ret['size'] > 0)
+        self.assertGreater(ret['size'], 0)
         self.assertEqual(ret['path'], path)
-        self.assert_(not os.path.exists(path))
+        self.assertNotExists(path)
 
     def test_Function(self):
         """Unit test for Function"""
@@ -62,19 +62,19 @@ class CommandTestCase(common.BleachbitTestCase):
         os.write(fd, "foo")
         os.close(fd)
         cmd = Function(path, FileUtilities.delete, 'bar')
-        self.assert_(os.path.exists(path))
-        self.assert_(os.path.getsize(path) > 0)
+        self.assertExists(path)
+        self.assertGreater(os.path.getsize(path), 0)
 
         # preview
         ret = cmd.execute(False).next()
-        self.assert_(os.path.exists(path))
-        self.assert_(os.path.getsize(path) > 0)
+        self.assertExists(path)
+        self.assertGreater(os.path.getsize(path), 0)
 
         # delete
         ret = cmd.execute(True).next()
-        self.assert_(ret['size'] > 0, 'Size is %d' % ret['size'])
+        self.assertGreater(ret['size'], 0)
         self.assertEqual(ret['path'], path)
-        self.assert_(not os.path.exists(path))
+        self.assertNotExists(path)
 
     def test_Shred(self):
         """Unit test for Shred"""

--- a/tests/TestCommand.py
+++ b/tests/TestCommand.py
@@ -21,25 +21,18 @@
 """
 Test case for Command
 """
-
-
 from __future__ import absolute_import, print_function
 
 from tests import common
 from bleachbit.Command import *
 
-import tempfile
-
 
 class CommandTestCase(common.BleachbitTestCase):
-
     """Test case for Command"""
 
     def test_Delete(self, cls=Delete):
         """Unit test for Delete"""
-        (fd, path) = tempfile.mkstemp(prefix='bleachbit-test-command')
-        os.write(fd, "foo")
-        os.close(fd)
+        path = self.write_file('test_Delete', b'foo')
         cmd = cls(path)
         self.assertExists(path)
 
@@ -58,9 +51,7 @@ class CommandTestCase(common.BleachbitTestCase):
 
     def test_Function(self):
         """Unit test for Function"""
-        (fd, path) = tempfile.mkstemp(prefix='bleachbit-test-command')
-        os.write(fd, "foo")
-        os.close(fd)
+        path = self.write_file('test_Function', b'foo')
         cmd = Function(path, FileUtilities.delete, 'bar')
         self.assertExists(path)
         self.assertGreater(os.path.getsize(path), 0)

--- a/tests/TestCommon.py
+++ b/tests/TestCommon.py
@@ -37,7 +37,7 @@ class CommonTestCase(common.BleachbitTestCase):
     def test_expandvars(self):
         """Unit test for expandvars."""
         var = bleachbit.expandvars('$HOME')
-        self.assertIsInstance(var, unicode)
+        self.assertIsUnicodeString(var)
 
     def test_environment(self):
         """Test for important environment variables"""
@@ -58,10 +58,10 @@ class CommonTestCase(common.BleachbitTestCase):
         """Unit test for expanduser."""
         # Return Unicode when given str.
         var = bleachbit.expanduser('~')
-        self.assertIsInstance(var, unicode)
+        self.assertIsUnicodeString(var)
         # Return Unicode when given Unicode.
         var = bleachbit.expanduser(u'~')
-        self.assertIsInstance(var, unicode)
+        self.assertIsUnicodeString(var)
         # Blank input should give blank output.
         self.assertEqual(bleachbit.expanduser(''), u'')
         # An absolute path should not be altered.
@@ -72,7 +72,7 @@ class CommonTestCase(common.BleachbitTestCase):
         self.assertExists(abs_dir)
         self.assertEqual(bleachbit.expanduser(abs_dir), abs_dir)
         # Path with tilde should be expanded
-        self.assertTrue(os.path.normpath(bleachbit.expanduser('~')), os.path.normpath(os.path.expanduser('~')))
+        self.assertEqual(os.path.normpath(bleachbit.expanduser('~')), os.path.normpath(os.path.expanduser('~')))
         # A relative path (without a reference to the home directory)
         # should not be expanded.
         self.assertEqual(bleachbit.expanduser('common'), 'common')

--- a/tests/TestCommon.py
+++ b/tests/TestCommon.py
@@ -28,11 +28,9 @@ from tests import common
 import bleachbit
 
 import os
-import tempfile
-import unittest
 
 
-class CommonTestCase(unittest.TestCase, common.AssertFile):
+class CommonTestCase(common.BleachbitTestCase):
 
     """Test case for Common."""
 
@@ -78,10 +76,3 @@ class CommonTestCase(unittest.TestCase, common.AssertFile):
         # A relative path (without a reference to the home directory)
         # should not be expanded.
         self.assertEqual(bleachbit.expanduser('common'), 'common')
-
-def suite():
-    return unittest.makeSuite(CommonTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestCommon.py
+++ b/tests/TestCommon.py
@@ -31,7 +31,6 @@ import os
 
 
 class CommonTestCase(common.BleachbitTestCase):
-
     """Test case for Common."""
 
     def test_expandvars(self):
@@ -43,36 +42,32 @@ class CommonTestCase(common.BleachbitTestCase):
         """Test for important environment variables"""
         # useful for researching
         # grep -Poh "([\\$%]\w+)" cleaners/*xml | cut -b2- | sort | uniq -i
-        if 'posix' == os.name:
-            envs = ('XDG_DATA_HOME', 'XDG_CONFIG_HOME', 'XDG_CACHE_HOME',
-                    'HOME')
-        else:
-            envs = ('AppData', 'CommonAppData', 'Documents', 'ProgramFiles',
-                    'UserProfile', 'WinDir')
-        for env in envs:
+        envs = {'posix': ['XDG_DATA_HOME', 'XDG_CONFIG_HOME', 'XDG_CACHE_HOME', 'HOME'],
+                'nt': ['AppData', 'CommonAppData', 'Documents', 'ProgramFiles', 'UserProfile', 'WinDir']}
+        for env in envs[os.name]:
             e = os.getenv(env)
             self.assertIsNotNone(e)
-            self.assertTrue(len(e) > 4)
+            self.assertGreater(len(e), 4)
 
     def test_expanduser(self):
         """Unit test for expanduser."""
         # Return Unicode when given str.
-        var = bleachbit.expanduser('~')
-        self.assertIsUnicodeString(var)
+        self.assertIsUnicodeString(bleachbit.expanduser('~'))
+
         # Return Unicode when given Unicode.
-        var = bleachbit.expanduser(u'~')
-        self.assertIsUnicodeString(var)
+        self.assertIsUnicodeString(bleachbit.expanduser(u'~'))
+
         # Blank input should give blank output.
         self.assertEqual(bleachbit.expanduser(''), u'')
+
         # An absolute path should not be altered.
-        if 'posix' == os.name:
-            abs_dir = os.path.expandvars('$HOME')
-        if 'nt' == os.name:
-            abs_dir = os.path.expandvars('%USERPROFILE%')
+        abs_dirs = {'posix': '$HOME', 'nt': '%USERPROFILE%'}
+        abs_dir = os.path.expandvars(abs_dirs[os.name])
         self.assertExists(abs_dir)
         self.assertEqual(bleachbit.expanduser(abs_dir), abs_dir)
         # Path with tilde should be expanded
-        self.assertEqual(os.path.normpath(bleachbit.expanduser('~')), os.path.normpath(os.path.expanduser('~')))
+        self.assertEqual(os.path.normpath(bleachbit.expanduser('~')),
+                         os.path.normpath(os.path.expanduser('~')))
         # A relative path (without a reference to the home directory)
         # should not be expanded.
         self.assertEqual(bleachbit.expanduser('common'), 'common')

--- a/tests/TestDeepScan.py
+++ b/tests/TestDeepScan.py
@@ -42,7 +42,7 @@ class DeepScanTestCase(common.BleachbitTestCase):
         """Test encoding"""
 
         tempd = tempfile.mkdtemp(prefix='bleachbit-test-deepscan')
-        self.assert_(os.path.exists(tempd))
+        self.assertExists(tempd)
 
         fullpath = os.path.join(tempd, fn)
         common.touch_file(fullpath)
@@ -58,16 +58,13 @@ class DeepScanTestCase(common.BleachbitTestCase):
         self.assert_(found, "Did not find '%s'" % fullpath)
 
         os.unlink(fullpath)
-        self.assert_(not os.path.exists(fullpath))
+        self.assertNotExists(fullpath)
         os.rmdir(tempd)
-        self.assert_(not os.path.exists(tempd))
+        self.assertNotExists(tempd)
 
     def test_encoding(self):
         """Test encoding"""
-        tests = ('äöüßÄÖÜ',
-                 "עִבְרִית")
-
-        for test in tests:
+        for test in ('äöüßÄÖÜ', "עִבְרִית"):
             self._test_encoding(test)
 
     def test_DeepScan(self):
@@ -83,10 +80,8 @@ class DeepScanTestCase(common.BleachbitTestCase):
             if True == ret:
                 # it's yielding control to the GTK idle loop
                 continue
-            self.assert_(isinstance(ret, (str, unicode)),
-                         "Expecting string but got '%s' (%s)" %
-                         (ret, str(type(ret))))
-            self.assert_(os.path.lexists(ret))
+            self.assertIsString(ret, "Expecting string but got '%s' (%s)" % (ret, str(type(ret))))
+            self.assertLExists(ret)
 
     def test_delete(self):
         """Delete files in a test environment"""
@@ -103,9 +98,9 @@ class DeepScanTestCase(common.BleachbitTestCase):
         open(f_del2, 'w').close()
 
         # sanity check
-        self.assert_(os.path.exists(f_del1))
-        self.assert_(os.path.exists(f_keep))
-        self.assert_(os.path.exists(f_del2))
+        self.assertExists(f_del1)
+        self.assertExists(f_keep)
+        self.assertExists(f_del2)
 
         # run deep scan
         astr = '<action command="delete" search="deep" regex="\.bbtestbak$" cache="false" path="%s"/>' % base
@@ -124,7 +119,7 @@ class DeepScanTestCase(common.BleachbitTestCase):
         # validate results
 
         self.assertFalse(os.path.exists(f_del1))
-        self.assert_(os.path.exists(f_keep))
+        self.assertExists(f_keep)
         self.assertFalse(os.path.exists(f_del2))
 
         # clean up

--- a/tests/TestDeepScan.py
+++ b/tests/TestDeepScan.py
@@ -32,10 +32,9 @@ from bleachbit import expanduser
 import os
 import shutil
 import tempfile
-import unittest
 
 
-class DeepScanTestCase(unittest.TestCase):
+class DeepScanTestCase(common.BleachbitTestCase):
 
     """Test Case for module DeepScan"""
 
@@ -153,11 +152,3 @@ class DeepScanTestCase(unittest.TestCase):
             ]
             mock_walk.return_value = expected
             self.assertEqual(list(normalized_walk('.')), expected)
-
-
-def suite():
-    return unittest.makeSuite(DeepScanTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestDiagnostic.py
+++ b/tests/TestDiagnostic.py
@@ -29,22 +29,12 @@ from __future__ import absolute_import, print_function
 from tests import common
 from bleachbit.Diagnostic import diagnostic_info
 
-import unittest
 
-class DiagnosticTestCase(unittest.TestCase):
-
+class DiagnosticTestCase(common.BleachbitTestCase):
     """Test Case for module Diagnostic"""
 
     def test_diagnostic_info(self):
         """Test diagnostic_info"""
         # at least it does not crash
         ret = diagnostic_info()
-        self.assert_(isinstance(ret, (str, unicode)))
-
-
-def suite():
-    return unittest.makeSuite(DiagnosticTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()
+        self.assertIsString(ret, (str, unicode))

--- a/tests/TestDiagnostic.py
+++ b/tests/TestDiagnostic.py
@@ -23,7 +23,6 @@
 Test case for module Diagnostic
 """
 
-
 from __future__ import absolute_import, print_function
 
 from tests import common
@@ -37,4 +36,4 @@ class DiagnosticTestCase(common.BleachbitTestCase):
         """Test diagnostic_info"""
         # at least it does not crash
         ret = diagnostic_info()
-        self.assertIsString(ret, (str, unicode))
+        self.assertIsString(ret)

--- a/tests/TestFileUtilities.py
+++ b/tests/TestFileUtilities.py
@@ -36,9 +36,6 @@ import sys
 import unittest
 
 
-
-
-
 def test_ini_helper(self, execute):
     """Used to test .ini cleaning in TestAction and in TestFileUtilities"""
 
@@ -116,8 +113,7 @@ def test_json_helper(self, execute):
     self.assert_(not os.path.exists(filename))
 
 
-class FileUtilitiesTestCase(unittest.TestCase, common.AssertFile):
-
+class FileUtilitiesTestCase(common.BleachbitTestCase):
     """Test case for module FileUtilities"""
 
     def test_bytes_to_human(self):
@@ -521,11 +517,10 @@ class FileUtilitiesTestCase(unittest.TestCase, common.AssertFile):
 
     def test_getsize(self):
         """Unit test for method getsize()"""
-        dirname = tempfile.mkdtemp(prefix='bleachbit-test-getsize')
+        dirname = tempfile.mkdtemp(prefix='bleachbit-test-getsize', dir=self.tempdir)
 
         def test_getsize_helper(fname):
-            filename = os.path.join(dirname, fname)
-            common.write_file(filename, "abcdefghij" * 12345)
+            filename = self.write_file(os.path.join(dirname, fname), "abcdefghij" * 12345)
 
             if 'nt' == os.name:
                 self.assertEqual(getsize(filename), 10 * 12345)
@@ -938,11 +933,3 @@ class FileUtilitiesTestCase(unittest.TestCase, common.AssertFile):
         self.assertEqual(list(open_files_lsof(lambda:
                                               'n/bar/foo\nn/foo/bar\nnoise'
                                               )), ['/bar/foo', '/foo/bar'])
-
-
-def suite():
-    return unittest.makeSuite(FileUtilitiesTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestGeneral.py
+++ b/tests/TestGeneral.py
@@ -32,7 +32,7 @@ from tests import common
 import unittest
 
 
-class GeneralTestCase(unittest.TestCase):
+class GeneralTestCase(common.BleachbitTestCase):
 
     """Test case for module General"""
 
@@ -168,11 +168,3 @@ class GeneralTestCase(unittest.TestCase):
     def test_sudo_mode(self):
         """Unit test for sudo_mode"""
         self.assert_(isinstance(sudo_mode(), bool))
-
-
-def suite():
-    return unittest.makeSuite(GeneralTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestGeneral.py
+++ b/tests/TestGeneral.py
@@ -22,7 +22,6 @@
 Test case for module General
 """
 
-
 from __future__ import absolute_import, print_function
 
 from bleachbit.General import *
@@ -52,19 +51,18 @@ class GeneralTestCase(common.BleachbitTestCase):
             self.assertRaises(RuntimeError, getrealuid)
             return
         uid = getrealuid()
-        self.assert_(isinstance(uid, int))
-        self.assert_(0 <= uid <= 65535)
+        self.assertIsInstance(uid, int)
+        self.assertTrue(0 <= uid <= 65535)
         if sudo_mode():
-            self.assert_(uid > 0)
+            self.assertGreater(uid, 0)
         logger.debug("os.getenv('LOGNAME') = %s", os.getenv('LOGNAME'))
         logger.debug("os.getenv('SUDO_UID') = %s", os.getenv('SUDO_UID'))
         logger.debug('os.geteuid() = %d', os.geteuid())
-        logger.debug('os.getuid() = %d', str(os.getuid()))
+        logger.debug('os.getuid() = %d', os.getuid())
         try:
             logger.debug('os.login() = %s', os.getlogin())
         except:
-            traceback.print_exc()
-            logger.debug('os.login() raised exception')
+            logger.exception('os.login() raised exception')
 
     def test_makedirs(self):
         """Unit test for makedirs"""
@@ -73,7 +71,7 @@ class GeneralTestCase(common.BleachbitTestCase):
                 return
             os.rmdir(dir)
             os.rmdir(os.path.dirname(dir))
-            self.assert_(not os.path.lexists(dir))
+            self.assertNotLExists(dir)
 
         if 'nt' == os.name:
             dir = 'c:\\temp\\bleachbit-test-makedirs\\a'
@@ -82,10 +80,10 @@ class GeneralTestCase(common.BleachbitTestCase):
         cleanup(dir)
         # directory does not exist
         makedirs(dir)
-        self.assert_(os.path.lexists(dir))
+        self.assertLExists(dir)
         # directory already exists
         makedirs(dir)
-        self.assert_(os.path.lexists(dir))
+        self.assertLExists(dir)
         # clean up
         cleanup(dir)
 
@@ -167,4 +165,4 @@ class GeneralTestCase(common.BleachbitTestCase):
     @unittest.skipUnless('posix' == os.name, 'skipping on platforms without sudo')
     def test_sudo_mode(self):
         """Unit test for sudo_mode"""
-        self.assert_(isinstance(sudo_mode(), bool))
+        self.assertIsInstance(sudo_mode(), bool)

--- a/tests/TestMemory.py
+++ b/tests/TestMemory.py
@@ -65,6 +65,7 @@ class MemoryTestCase(common.BleachbitTestCase):
         self.assertTrue(0 <= n_swaps < 10)
 
     def test_physical_free_darwin(self):
+        # TODO: use mock
         self.assertEqual(physical_free_darwin(lambda:
 """Mach Virtual Memory Statistics: (page size of 4096 bytes)
 Pages free:                              836891.
@@ -105,8 +106,7 @@ Swapouts:                              20258188.
         with open('/proc/swaps') as f:
             swapdev = f.read().split('\n')[1].split(' ')[0]
         if 0 == len(swapdev):
-            print('no active swap device detected')
-            return
+            self.skipTest('no active swap device detected')
         size = get_swap_size_linux(swapdev)
         self.assertIsInteger(size)
         self.assertGreater(size, 1024 ** 2)

--- a/tests/TestMemory.py
+++ b/tests/TestMemory.py
@@ -27,14 +27,13 @@ from __future__ import absolute_import, print_function
 from tests import common
 from bleachbit.Memory import *
 
-
 import unittest
 import sys
 
 running_linux = sys.platform.startswith('linux')
 
 
-class MemoryTestCase(unittest.TestCase):
+class MemoryTestCase(common.BleachbitTestCase):
     """Test case for module Memory"""
 
     @unittest.skipUnless(running_linux, 'not running linux')
@@ -143,11 +142,3 @@ Swapouts:                              20258188.
             self.skipTest('not enough privileges')
         devices = disable_swap_linux()
         enable_swap_linux()
-
-
-def suite():
-    return unittest.makeSuite(MemoryTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestMemory.py
+++ b/tests/TestMemory.py
@@ -40,11 +40,9 @@ class MemoryTestCase(common.BleachbitTestCase):
     def test_get_proc_swaps(self):
         """Test for method get_proc_swaps"""
         ret = get_proc_swaps()
-        self.assert_(isinstance(ret, str))
-        self.assert_(len(ret) > 10)
+        self.assertGreater(len(ret), 10)
         if not re.search('Filename\s+Type\s+Size', ret):
-            raise RuntimeError(
-                "Unexpected first line in swap summary '%s'" % ret)
+            raise RuntimeError("Unexpected first line in swap summary '%s'" % ret)
 
     @unittest.skipUnless(running_linux, 'not running linux')
     def test_make_self_oom_target_linux(self):
@@ -63,9 +61,8 @@ class MemoryTestCase(common.BleachbitTestCase):
     def test_count_linux_swap(self):
         """Test for method count_linux_swap"""
         n_swaps = count_swap_linux()
-        self.assert_(isinstance(n_swaps, (int, long)))
-        self.assert_(n_swaps >= 0)
-        self.assert_(n_swaps < 10)
+        self.assertIsInteger(n_swaps)
+        self.assertTrue(0 <= n_swaps < 10)
 
     def test_physical_free_darwin(self):
         self.assertEqual(physical_free_darwin(lambda:
@@ -93,29 +90,29 @@ Pageouts:                              30477017.
 Swapins:                               19424481.
 Swapouts:                              20258188.
 """), 3427905536)
-        self.assertRaises(
-            RuntimeError, physical_free_darwin, lambda: "Invalid header")
+        self.assertRaises(RuntimeError, physical_free_darwin, lambda: "Invalid header")
 
     def test_physical_free(self):
         """Test for method physical_free"""
         ret = physical_free()
-        self.assert_(isinstance(ret, (int, long)),
-                     'physical_free() returns variable type %s' % type(ret))
-        self.assert_(physical_free() > 0)
+        self.assertIsInteger(ret, 'physical_free() returns variable type %s' % type(ret))
+        self.assertGreater(physical_free(), 0)
         report_free()
 
     @unittest.skipUnless(running_linux, 'not running linux')
     def test_get_swap_size_linux(self):
         """Test for get_swap_size_linux()"""
-        swapdev = open('/proc/swaps').read().split('\n')[1].split(' ')[0]
+        with open('/proc/swaps') as f:
+            swapdev = f.read().split('\n')[1].split(' ')[0]
         if 0 == len(swapdev):
             print('no active swap device detected')
             return
         size = get_swap_size_linux(swapdev)
-        self.assert_(isinstance(size, (int, long)))
-        self.assert_(size > 1024 ** 2)
+        self.assertIsInteger(size)
+        self.assertGreater(size, 1024 ** 2)
         logger.debug("size of swap '%s': %d B (%d MB)", swapdev, size, size / (1024 ** 2))
-        proc_swaps = open('/proc/swaps').read()
+        with open('/proc/swaps') as f:
+            proc_swaps = f.read()
         size2 = get_swap_size_linux(swapdev, proc_swaps)
         self.assertEqual(size, size2)
 
@@ -140,5 +137,5 @@ Swapouts:                              20258188.
         """Test for disabling and enabling swap"""
         if not General.sudo_mode() or os.getuid() > 0:
             self.skipTest('not enough privileges')
-        devices = disable_swap_linux()
+        disable_swap_linux()
         enable_swap_linux()

--- a/tests/TestOptions.py
+++ b/tests/TestOptions.py
@@ -24,14 +24,14 @@ Test case for module Options
 
 from __future__ import absolute_import, print_function
 
+from tests import common
 import bleachbit.Options
 from bleachbit import NoOptionError
 
 import os
-import unittest
 
 
-class OptionsTestCase(unittest.TestCase):
+class OptionsTestCase(common.BleachbitTestCase):
 
     """Test case for class Options"""
 
@@ -160,11 +160,3 @@ class OptionsTestCase(unittest.TestCase):
 
         # clean up
         del o
-
-
-def suite():
-    return unittest.makeSuite(OptionsTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestOptions.py
+++ b/tests/TestOptions.py
@@ -31,7 +31,6 @@ import os
 
 
 class OptionsTestCase(common.BleachbitTestCase):
-
     """Test case for class Options"""
 
     def test_Options(self):
@@ -105,11 +104,7 @@ class OptionsTestCase(common.BleachbitTestCase):
         # By default ConfigParser stores keys (the filenames) as lowercase.
         # This needs special consideration when combined with purging.
         o1 = bleachbit.Options.Options()
-        import tempfile
-        dirname = tempfile.mkdtemp(prefix='bleachbit-test-options')
-        pathname = os.path.join(dirname, 'foo.xml')
-        open(pathname, 'w').close()  # make an empty file
-        self.assertTrue(os.path.exists(pathname))
+        pathname = self.write_file('foo.xml')
         myhash = '0ABCD'
         o1.set_hashpath(pathname, myhash)
         self.assertEqual(myhash, o1.get_hashpath(pathname))
@@ -135,9 +130,6 @@ class OptionsTestCase(common.BleachbitTestCase):
         o3.set('dummypath', 'dummyvalue', 'hashpath')
         # verify the path was purged
         self.assertRaises(NoOptionError, lambda: o3.get_hashpath(pathname))
-
-        # clean up
-        os.rmdir(dirname)
 
     def test_abbreviations(self):
         """Test non-standard, abbreviated booleans T and F"""

--- a/tests/TestOptions.py
+++ b/tests/TestOptions.py
@@ -21,7 +21,6 @@
 """
 Test case for module Options
 """
-
 from __future__ import absolute_import, print_function
 
 from tests import common
@@ -65,25 +64,25 @@ class OptionsTestCase(common.BleachbitTestCase):
         self.assertEqual(list_values, o.get_list("list_test"))
 
         # whitelist
-        self.assert_(type(o.get_whitelist_paths() is list))
+        self.assertIsInstance(o.get_whitelist_paths(), list)
         whitelist = [('file', '/home/foo'), ('folder', '/home')]
         old_whitelist = o.get_whitelist_paths()
         o.config.remove_section('whitelist/paths')
-        self.assert_(type(o.get_whitelist_paths() is list))
+        self.assertIsInstance(o.get_whitelist_paths(), list)
         self.assertEqual(o.get_whitelist_paths(), [])
         o.set_whitelist_paths(whitelist)
-        self.assert_(type(o.get_whitelist_paths() is list))
+        self.assertIsInstance(o.get_whitelist_paths(), list)
         self.assertEqual(set(whitelist), set(o.get_whitelist_paths()))
         o.set_whitelist_paths(old_whitelist)
         self.assertEqual(set(old_whitelist), set(o.get_whitelist_paths()))
 
         # these should always be set
         for bkey in bleachbit.Options.boolean_keys:
-            self.assert_(isinstance(o.get(bkey), bool))
+            self.assertIsInstance(o.get(bkey), bool)
 
         # language
         value = o.get_language('en')
-        self.assert_(isinstance(value, bool))
+        self.assertIsInstance(value, bool)
         o.set_language('en', True)
         self.assertTrue(o.get_language('en'))
         o.set_language('en', False)

--- a/tests/TestRecognizeCleanerML.py
+++ b/tests/TestRecognizeCleanerML.py
@@ -24,12 +24,11 @@ Test case for RecognizeCleanerML
 
 from __future__ import absolute_import, print_function
 
+from tests import common
 from bleachbit.RecognizeCleanerML import hashdigest
 
-import unittest
 
-
-class RecognizeCleanerMLTestCase(unittest.TestCase):
+class RecognizeCleanerMLTestCase(common.BleachbitTestCase):
 
     """Test case for RecognizeCleanerML"""
 
@@ -39,10 +38,3 @@ class RecognizeCleanerMLTestCase(unittest.TestCase):
         self.assertEqual(len(digest), 128)
         self.assertEqual(digest[1:10], '6382c203e')
 
-
-def suite():
-    return unittest.makeSuite(RecognizeCleanerMLTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestRecognizeCleanerML.py
+++ b/tests/TestRecognizeCleanerML.py
@@ -29,7 +29,6 @@ from bleachbit.RecognizeCleanerML import hashdigest
 
 
 class RecognizeCleanerMLTestCase(common.BleachbitTestCase):
-
     """Test case for RecognizeCleanerML"""
 
     def test_hash(self):

--- a/tests/TestSpecial.py
+++ b/tests/TestSpecial.py
@@ -34,7 +34,6 @@ import os.path
 import shutil
 import sqlite3
 import tempfile
-import unittest
 
 
 chrome_bookmarks = """
@@ -187,7 +186,7 @@ class SpecialAssertions:
             raise AssertionError('Table is not empty: %s ' % table)
 
 
-class SpecialTestCase(unittest.TestCase, SpecialAssertions):
+class SpecialTestCase(common.BleachbitTestCase, SpecialAssertions):
 
     """Test case for module Special"""
 
@@ -383,11 +382,3 @@ INSERT INTO "meta" VALUES('version','20');"""
         ver = Special.get_sqlite_int(
             filename, 'select value from meta where key="version"')
         self.assertEqual(ver, [20])
-
-
-def suite():
-    return unittest.makeSuite(SpecialTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -30,7 +30,6 @@ import bleachbit
 from bleachbit.Unix import *
 
 import sys
-import tempfile
 import unittest
 
 
@@ -103,21 +102,21 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
 
     def test_locale_regex(self):
         """Unit test for locale_to_language()"""
-        tests = [('en', 'en'),
-                 ('en_US', 'en'),
-                 ('en_US@piglatin', 'en'),
-                 ('en_US.utf8', 'en'),
-                 ('ko_KR.eucKR', 'ko'),
-                 ('pl.ISO8859-2', 'pl'),
-                 ('zh_TW.Big5', 'zh')]
+        tests = {'en': 'en',
+                 'en_US': 'en',
+                 'en_US@piglatin': 'en',
+                 'en_US.utf8': 'en',
+                 'ko_KR.eucKR': 'ko',
+                 'pl.ISO8859-2': 'pl',
+                 'zh_TW.Big5': 'zh'}
         import re
         regex = re.compile('^' + Locales.localepattern + '$')
-        for test in tests:
-            m = regex.match(test[0])
-            self.assertIsNotNone(m, 'expected positive match for ' + test[0])
-            self.assertEqual(m.group("locale"), test[1])
+        for locale, tlc in tests.items():
+            m = regex.match(locale)
+            self.assertIsNotNone(m, 'expected positive match for ' + locale)
+            self.assertEqual(m.group("locale"), tlc)
         for test in ['default', 'C', 'English', 'ru_RU.txt', 'ru.txt']:
-            self.assertIsNone(regex.match(test), 'expected negative match for '+test)
+            self.assertIsNone(regex.match(test), 'expected negative match for ' + test)
 
     def test_localization_paths(self):
         """Unit test for localization_paths()"""
@@ -130,15 +129,13 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
             self.assertLExists(path)
             # self.assert_(path.startswith('/usr/share/locale'))
             # /usr/share/locale/en_* should be ignored
-            self.assert_(path.find('/en_') == -1)
+            self.assertEqual(path.find('/en_'), -1)
             counter += 1
-        self.assert_(
-            counter > 0, 'Zero files deleted by localization cleaner.'
-                         'This may be an error unless you really deleted all the files.')
+        self.assertGreater(counter, 0, 'Zero files deleted by localization cleaner.' +
+                                       'This may be an error unless you really deleted all the files.')
 
     def test_fakelocalizationdirs(self):
         """Create a faked localization hierarchy and clean it afterwards"""
-        dirname = tempfile.mkdtemp(prefix='bleachbit-test-localizations')
 
         keepdirs = [
             'important_dontdelete',
@@ -161,9 +158,9 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
             'delete/dummyfiles/ru.txt',
             'delete/locale/ru_RU.UTF8.txt']
         for path in keepdirs + nukedirs:
-            os.mkdir(os.path.join(dirname, path))
+            os.mkdir(os.path.join(self.tempdir, path))
         for path in keepfiles + nukefiles:
-            open(os.path.join(dirname, path), 'w').close()
+            self.write_file(path)
 
         configxml = '<path directoryregex="^.*$">' \
                     '  <path directoryregex="^(locale|dummyfiles)$">' \
@@ -173,15 +170,14 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
                     '</path>'
         from xml.dom.minidom import parseString
         config = parseString(configxml)
-        locales = Locales()
-        locales._paths = LocaleCleanerPath(dirname)
-        locales.add_xml(config.firstChild, None)
+        self.locales._paths = LocaleCleanerPath(self.tempdir)
+        self.locales.add_xml(config.firstChild, None)
         # normpath because paths may contain ./
-        deletelist = [os.path.normpath(path) for path in locales.localization_paths(['en', 'de'])]
+        deletelist = [os.path.normpath(path) for path in self.locales.localization_paths(['en', 'de'])]
         for path in keepdirs + keepfiles:
-            self.assert_(os.path.join(dirname, path) not in deletelist)
+            self.assertNotIn(os.path.join(self.tempdir, path), deletelist)
         for path in nukedirs + nukefiles:
-            self.assert_(os.path.join(dirname, path) in deletelist)
+            self.assertIn(os.path.join(self.tempdir, path), deletelist)
 
     def test_rotated_logs(self):
         """Unit test for rotated_logs()"""
@@ -209,8 +205,7 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
         b = start_with_computer_check()
         self.assertIsInstance(b, bool)
 
-        if not os.path.exists(bleachbit.launcher_path) and \
-                os.path.exists('bleachbit.desktop'):
+        if not os.path.exists(bleachbit.launcher_path) and  os.path.exists('bleachbit.desktop'):
             # this happens when BleachBit is not installed
             bleachbit.launcher_path = 'bleachbit.desktop'
 
@@ -227,11 +222,10 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
 
     def test_wine_to_linux_path(self):
         """Unit test for wine_to_linux_path()"""
-        tests = [("/home/foo/.wine",
-                  "C:\\Program Files\\NSIS\\NSIS.exe",
-                  "/home/foo/.wine/drive_c/Program Files/NSIS/NSIS.exe")]
-        for test in tests:
-            self.assertEqual(wine_to_linux_path(test[0], test[1]), test[2])
+        wineprefix = "/home/foo/.wine"
+        windows_pathname = "C:\\Program Files\\NSIS\\NSIS.exe"
+        result = "/home/foo/.wine/drive_c/Program Files/NSIS/NSIS.exe"
+        self.assertEqual(wine_to_linux_path(wineprefix, windows_pathname), result)
 
     def test_yum_clean(self):
         """Unit test for yum_clean()"""

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -35,7 +35,7 @@ import unittest
 
 
 @unittest.skipIf('win32' == sys.platform, 'skipping unix tests on windows')
-class UnixTestCase(unittest.TestCase):
+class UnixTestCase(common.BleachbitTestCase):
 
     """Test case for module Unix"""
 
@@ -243,11 +243,3 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
             bytes_freed = yum_clean()
             self.assert_(isinstance(bytes_freed, (int, long)))
             bleachbit.logger.debug('yum bytes cleaned %d', bytes_freed)
-
-
-def suite():
-    return unittest.makeSuite(UnixTestCase)
-
-
-if __name__ == '__main__' and 'posix' == os.name:
-    unittest.main()

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -50,9 +50,9 @@ class UnixTestCase(common.BleachbitTestCase):
             self.assertRaises(RuntimeError, apt_autoremove)
         else:
             bytes_freed = apt_autoclean()
-            self.assert_(isinstance(bytes_freed, (int, long)))
+            self.assertIsInteger(bytes_freed)
             bytes_freed = apt_autoremove()
-            self.assert_(isinstance(bytes_freed, (int, long)))
+            self.assertIsInteger(bytes_freed)
 
     def test_is_broken_xdg_desktop(self):
         """Unit test for is_broken_xdg_desktop()"""
@@ -66,7 +66,7 @@ class UnixTestCase(common.BleachbitTestCase):
         for dirname in menu_dirs:
             for filename in [fn for fn in FileUtilities.children_in_directory(dirname, False)
                              if fn.endswith('.desktop')]:
-                self.assert_(type(is_broken_xdg_desktop(filename) is bool))
+                self.assertIsInstance(is_broken_xdg_desktop(filename), bool)
 
     def test_is_running_darwin(self):
         def run_ps():
@@ -114,10 +114,10 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
         regex = re.compile('^' + Locales.localepattern + '$')
         for test in tests:
             m = regex.match(test[0])
-            self.assert_(m is not None, 'expected positive match for ' + test[0])
+            self.assertIsNotNone(m, 'expected positive match for ' + test[0])
             self.assertEqual(m.group("locale"), test[1])
         for test in ['default', 'C', 'English', 'ru_RU.txt', 'ru.txt']:
-            self.assert_(regex.match(test) is None, 'expected negative match for '+test)
+            self.assertIsNone(regex.match(test), 'expected negative match for '+test)
 
     def test_localization_paths(self):
         """Unit test for localization_paths()"""
@@ -127,7 +127,7 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
         locales.add_xml(configpath)
         counter = 0
         for path in locales.localization_paths(['en']):
-            self.assert_(os.path.lexists(path))
+            self.assertLExists(path)
             # self.assert_(path.startswith('/usr/share/locale'))
             # /usr/share/locale/en_* should be ignored
             self.assert_(path.find('/en_') == -1)
@@ -186,8 +186,7 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
     def test_rotated_logs(self):
         """Unit test for rotated_logs()"""
         for path in rotated_logs():
-            self.assert_(os.path.exists(path),
-                         "Rotated log path '%s' does not exist" % path)
+            self.assertLExists(path, "Rotated log path '%s' does not exist" % path)
 
     def test_run_cleaner_cmd(self):
         from subprocess import CalledProcessError
@@ -208,7 +207,7 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
     def test_start_with_computer(self):
         """Unit test for start_with_computer*"""
         b = start_with_computer_check()
-        self.assert_(isinstance(b, bool))
+        self.assertIsInstance(b, bool)
 
         if not os.path.exists(bleachbit.launcher_path) and \
                 os.path.exists('bleachbit.desktop'):
@@ -218,12 +217,12 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
         # opposite setting
         start_with_computer(not b)
         two_b = start_with_computer_check()
-        self.assert_(isinstance(two_b, bool))
-        self.assertEqual(b, not two_b)
+        self.assertIsInstance(two_b, bool)
+        self.assertNotEqual(b, two_b)
         # original setting
         start_with_computer(b)
         three_b = start_with_computer_check()
-        self.assert_(isinstance(b, bool))
+        self.assertIsInstance(b, bool)
         self.assertEqual(b, three_b)
 
     def test_wine_to_linux_path(self):
@@ -241,5 +240,5 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
             self.assertRaises(RuntimeError, yum_clean)
         else:
             bytes_freed = yum_clean()
-            self.assert_(isinstance(bytes_freed, (int, long)))
+            self.assertIsInteger(bytes_freed)
             bleachbit.logger.debug('yum bytes cleaned %d', bytes_freed)

--- a/tests/TestUpdate.py
+++ b/tests/TestUpdate.py
@@ -33,10 +33,9 @@ import bleachbit.Update
 
 import os
 import os.path
-import unittest
 
 
-class UpdateTestCase(unittest.TestCase):
+class UpdateTestCase(common.BleachbitTestCase):
 
     """Test case for module Update"""
 
@@ -157,11 +156,3 @@ class UpdateTestCase(unittest.TestCase):
         import socket
         self.assertTrue(hasattr(socket, 'ssl'))
         import _ssl
-
-
-def suite():
-    return unittest.makeSuite(UpdateTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestUpdate.py
+++ b/tests/TestUpdate.py
@@ -36,31 +36,26 @@ import os.path
 
 
 class UpdateTestCase(common.BleachbitTestCase):
-
     """Test case for module Update"""
 
     def test_UpdateCheck_fake(self):
         """Unit tests for class UpdateCheck using fake network"""
 
-        update_tests = []
         wa = '<winapp2 url="http://katana.oooninja.com/bleachbit/winapp2.ini" sha512="ce9e18252f608c8aff28811e372124d29a86404f328d3cd51f1f220578744bb8b15f55549eabfe8f1a80657fc940f6d6deece28e0532b3b0901a4c74110f7ba7"/>'
-        update_tests.append(
+        update_tests = [
             ('<updates><stable ver="0.8.4">http://084</stable><beta ver="0.8.5beta">http://085beta</beta>%s</updates>' % wa,
-                           ((u'0.8.4', u'http://084'), (u'0.8.5beta', u'http://085beta'))))
-        update_tests.append(
+                           ((u'0.8.4', u'http://084'), (u'0.8.5beta', u'http://085beta'))),
             ('<updates><stable ver="0.8.4">http://084</stable>%s</updates>' % wa,
-                           ((u'0.8.4', u'http://084'), )))
-        update_tests.append(
+                           ((u'0.8.4', u'http://084'), )),
             ('<updates><beta ver="0.8.5beta">http://085beta</beta>%s</updates>' % wa,
-                           ((u'0.8.5beta', u'http://085beta'), )))
-        update_tests.append(('<updates></updates>', ()))
+                           ((u'0.8.5beta', u'http://085beta'), )),
+            ('<updates></updates>', ())]
 
         # fake network
         original_open = bleachbit.Update.build_opener
         xml = ""
 
-        class fake_opener:
-
+        class FakeOpener:
             def add_headers(self):
                 pass
 
@@ -70,15 +65,14 @@ class UpdateTestCase(common.BleachbitTestCase):
             def open(self, url):
                 return self
 
-        bleachbit.Update.build_opener = fake_opener
-        for update_test in update_tests:
-            xml = update_test[0]
+        # TODO: mock
+        bleachbit.Update.build_opener = FakeOpener
+        for xml, expected in update_tests:
             updates = check_updates(True, False, None, None)
-            self.assertEqual(updates, update_test[1])
+            self.assertEqual(updates, expected)
         bleachbit.Update.build_opener = original_open
 
-
-    def test_UpdateCheck_real(self):
+    def test_UpdateCheck_real_network(self):
         """Unit tests for class UpdateCheck using real network"""
 
         # real network
@@ -87,8 +81,8 @@ class UpdateTestCase(common.BleachbitTestCase):
                 continue
             ver = update[0]
             url = update[1]
-            self.assert_(isinstance(ver, (type(None), unicode)))
-            self.assert_(isinstance(url, (type(None), unicode)))
+            self.assertIsInstance(ver, (type(None), unicode))
+            self.assertIsInstance(url, (type(None), unicode))
 
     def test_UpdateCheck_real(self):
         """Unit test for class UpdateCheck with bad network address"""
@@ -107,7 +101,7 @@ class UpdateTestCase(common.BleachbitTestCase):
         handle = opener.open(bleachbit.update_check_url)
         doc = handle.read()
         import xml
-        dom = xml.dom.minidom.parseString(doc)
+        xml.dom.minidom.parseString(doc)
 
     def test_update_winapp2(self):
         from bleachbit import personal_cleaners_dir
@@ -118,30 +112,24 @@ class UpdateTestCase(common.BleachbitTestCase):
 
         url = 'http://katana.oooninja.com/bleachbit/winapp2/winapp2-2016-03-14.ini'
 
-        def append_text(s):
-            print(s)
-
-        succeeded = {'r': False}  # scope
+        def expect_failure():
+            raise AssertionError('Call should have failed')
 
         def on_success():
             succeeded['r'] = True
 
+        succeeded = {'r': False}  # scope
+
         # bad hash
-        succeeded['r'] = False
-        self.assertRaises(RuntimeError, update_winapp2, url, "notahash",
-                          append_text, on_success)
-        self.assertFalse(succeeded['r'])
+        self.assertRaises(RuntimeError, update_winapp2, url, "notahash", print, expect_failure)
 
         # blank hash, download file
-        succeeded['r'] = False
-        update_winapp2(url, None, append_text, on_success)
+        update_winapp2(url, None, print, on_success)
         self.assertTrue(succeeded['r'])
 
         # blank hash, do not download again
-        update_winapp2(url, None, append_text, on_success)
-        succeeded['r'] = False
-        update_winapp2(url, None, append_text, on_success)
-        self.assertFalse(succeeded['r'])
+        update_winapp2(url, None, print, on_success)
+        update_winapp2(url, None, print, expect_failure)
 
     def test_user_agent(self):
         """Unit test for method user_agent()"""
@@ -155,4 +143,3 @@ class UpdateTestCase(common.BleachbitTestCase):
         self.assertTrue(hasattr(httplib, 'HTTPS'))
         import socket
         self.assertTrue(hasattr(socket, 'ssl'))
-        import _ssl

--- a/tests/TestUpdate.py
+++ b/tests/TestUpdate.py
@@ -130,24 +130,24 @@ class UpdateTestCase(common.BleachbitTestCase):
         succeeded['r'] = False
         self.assertRaises(RuntimeError, update_winapp2, url, "notahash",
                           append_text, on_success)
-        self.assert_(not succeeded['r'])
+        self.assertFalse(succeeded['r'])
 
         # blank hash, download file
         succeeded['r'] = False
         update_winapp2(url, None, append_text, on_success)
-        self.assert_(succeeded['r'])
+        self.assertTrue(succeeded['r'])
 
         # blank hash, do not download again
         update_winapp2(url, None, append_text, on_success)
         succeeded['r'] = False
         update_winapp2(url, None, append_text, on_success)
-        self.assert_(not succeeded['r'])
+        self.assertFalse(succeeded['r'])
 
     def test_user_agent(self):
         """Unit test for method user_agent()"""
         agent = user_agent()
         logger.debug("user agent = '%s'", agent)
-        self.assert_(isinstance(agent, str))
+        self.assertIsString(agent)
 
     def test_environment(self):
         """Check the sanity of the environment"""

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -69,7 +69,7 @@ def get_winapp2():
 
 
 @unittest.skipUnless('win32' == sys.platform, 'not running on windows')
-class WinappTestCase(unittest.TestCase, common.AssertFile):
+class WinappTestCase(common.BleachbitTestCase):
 
     """Test cases for Winapp"""
 
@@ -404,11 +404,3 @@ class WinappTestCase(unittest.TestCase, common.AssertFile):
                  ('A - B (C)', 'a_b_c'))
         for test in tests:
             self.assertEqual(section2option(test[0]), test[1])
-
-
-def suite():
-    return unittest.makeSuite(WinappTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -70,7 +70,6 @@ def get_winapp2():
 
 @unittest.skipUnless('win32' == sys.platform, 'not running on windows')
 class WinappTestCase(common.BleachbitTestCase):
-
     """Test cases for Winapp"""
 
     def run_all(self, cleaner, really_delete):

--- a/tests/TestWindows.py
+++ b/tests/TestWindows.py
@@ -59,7 +59,7 @@ def put_files_into_recycle_bin():
 
 
 @unittest.skipUnless('win32' == sys.platform, 'not running on windows')
-class WindowsTestCase(unittest.TestCase, common.AssertFile):
+class WindowsTestCase(common.BleachbitTestCase):
 
     """Test case for module Windows"""
 
@@ -254,8 +254,7 @@ class WindowsTestCase(unittest.TestCase, common.AssertFile):
             logger.debug('file_wipe(%s)', longname)
 
             def _write_file(longname, contents):
-                common.write_file(longname, contents)
-                self.assertExists(longname)
+                self.write_file(longname, contents)
                 return longname
                 import win32api
                 shortname = extended_path_undo(
@@ -365,11 +364,3 @@ class WindowsTestCase(unittest.TestCase, common.AssertFile):
         """Unit test for shell_change_notify"""
         ret = shell_change_notify()
         self.assertEqual(ret, 0)
-
-
-def suite():
-    return unittest.makeSuite(WindowsTestCase)
-
-
-if __name__ == '__main__' and sys.platform == 'win32':
-    unittest.main()

--- a/tests/TestWorker.py
+++ b/tests/TestWorker.py
@@ -194,7 +194,7 @@ class TruncateTestAction(ActionProvider):
         yield Command.Delete(self.pathname)
 
 
-class WorkerTestCase(unittest.TestCase):
+class WorkerTestCase(common.BleachbitTestCase):
 
     """Test case for module Worker"""
 
@@ -337,11 +337,3 @@ class WorkerTestCase(unittest.TestCase):
         self.assertEqual(worker.total_special, 0)
         self.assertEqual(worker.total_errors, 0)
         self.assertEqual(worker.total_deleted, 2)
-
-
-def suite():
-    return unittest.makeSuite(WorkerTestCase)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/TestWorker.py
+++ b/tests/TestWorker.py
@@ -205,7 +205,7 @@ class WorkerTestCase(common.BleachbitTestCase):
         (fd, filename) = tempfile.mkstemp(prefix='bleachbit-test-worker')
         os.write(fd, '123')
         os.close(fd)
-        self.assert_(os.path.exists(filename))
+        self.assertExists(filename)
         astr = '<action command="%s" path="%s"/>' % (command, filename)
         cleaner = TestCleaner.action_to_cleaner(astr)
         backends['test'] = cleaner
@@ -214,8 +214,7 @@ class WorkerTestCase(common.BleachbitTestCase):
         run = worker.run()
         while run.next():
             pass
-        self.assert_(not os.path.exists(filename),
-                     "Path still exists '%s'" % filename)
+        self.assertNotExists(filename, "Path still exists '%s'" % filename)
         self.assertEqual(worker.total_special, special_expected,
                          'For command %s expecting %s special operations but observed %d'
                          % (command, special_expected, worker.total_special))
@@ -316,10 +315,10 @@ class WorkerTestCase(common.BleachbitTestCase):
         ui = CLI.CliCallback()
         (fd, filename1) = tempfile.mkstemp(prefix='bleachbit-test-worker')
         os.close(fd)
-        self.assert_(os.path.exists(filename1))
+        self.assertExists(filename1)
         (fd, filename2) = tempfile.mkstemp(prefix='bleachbit-test-worker')
         os.close(fd)
-        self.assert_(os.path.exists(filename2))
+        self.assertExists(filename2)
 
         astr1 = '<action command="delete" search="file" path="%s"/>' % filename1
         astr2 = '<action command="delete" search="file" path="%s"/>' % filename2
@@ -330,10 +329,8 @@ class WorkerTestCase(common.BleachbitTestCase):
         run = worker.run()
         while run.next():
             pass
-        self.assert_(not os.path.exists(filename1),
-                     "Path still exists '%s'" % filename1)
-        self.assert_(not os.path.exists(filename2),
-                     "Path still exists '%s'" % filename2)
+        self.assertNotExists(filename1, "Path still exists '%s'" % filename1)
+        self.assertNotExists(filename2, "Path still exists '%s'" % filename2)
         self.assertEqual(worker.total_special, 0)
         self.assertEqual(worker.total_errors, 0)
         self.assertEqual(worker.total_deleted, 2)

--- a/tests/common.py
+++ b/tests/common.py
@@ -95,11 +95,22 @@ class BleachbitTestCase(unittest.TestCase):
         """Create a temporary file, optionally writing contents to it"""
         if not os.path.isabs(filename):
             filename = os.path.join(self.tempdir, filename)
-        filename = extended_path(filename)
-        with open(filename, 'w') as f:
+        with open(extended_path(filename), 'wb') as f:
             f.write(contents)
-        assert (os.path.exists(filename))
+        assert (os.path.exists(extended_path(filename)))
         return filename
+
+    def mkstemp(self, **kwargs):
+        if 'dir' not in kwargs:
+            kwargs['dir'] = self.tempdir
+        (fd, filename) = tempfile.mkstemp(**kwargs)
+        os.close(fd)
+        return filename
+
+    def mkdtemp(self, **kwargs):
+        if 'dir' not in kwargs:
+            kwargs['dir'] = self.tempdir
+        return tempfile.mkdtemp(**kwargs)
 
 
 def getTestPath(path):
@@ -120,7 +131,6 @@ def touch_file(filename):
     """Create an empty file"""
     with open(filename, "w") as f:
         pass
-    import os.path
     assert(os.path.exists(filename))
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -53,6 +53,9 @@ class BleachbitTestCase(unittest.TestCase):
     def assertIsInteger(self, obj, msg=''):
         self.assertIsInstance(obj, (int, long), msg)
 
+    def assertIsUnicodeString(self, obj, msg=''):
+        self.assertIsInstance(obj, unicode, msg)
+
     def assertIsString(self, obj, msg=''):
         self.assertIsInstance(obj, (unicode, str), msg)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -26,24 +26,48 @@ from __future__ import absolute_import, print_function
 
 from bleachbit.FileUtilities import extended_path
 
+import unittest
+import shutil
 import tempfile
 import os
+import os.path
 
 
-class AssertFile:
+class BleachbitTestCase(unittest.TestCase):
+    """TestCase class with several convenience methods and asserts"""
 
-    def getTestPath(self, path):
-        if 'nt' == os.name:
-            return extended_path(os.path.normpath(path))
-        return path
+    @classmethod
+    def setUpClass(cls):
+        """Create a temporary directory for the testcase"""
+        cls.tempdir = tempfile.mkdtemp(prefix=cls.__name__)
+        print(cls.tempdir)
 
+    @classmethod
+    def tearDownClass(cls):
+        """remove the temporary directory"""
+        shutil.rmtree(cls.tempdir)
+
+    #
+    # type asserts
+    #
+    def assertIsInteger(self, obj, msg=''):
+        self.assertIsInstance(obj, (int, long), msg)
+
+    def assertIsString(self, obj, msg=''):
+        self.assertIsInstance(obj, (unicode, str), msg)
+
+    def assertIsBytes(self, obj, msg=''):
+        self.assertIsInstance(obj, bytes, msg)
+
+    #
+    # file asserts
+    #
     def assertExists(self, path, msg='', func=os.path.exists):
         """File, directory, or any path exists"""
         from bleachbit import expandvars
         path = expandvars(path)
-        if not func(self.getTestPath(path)):
-            raise AssertionError(
-                'The file %s should exist, but it does not. %s' % (path, msg))
+        if not func(getTestPath(path)):
+            raise AssertionError('The file %s should exist, but it does not. %s' % (path, msg))
 
     def assertLExists(self, path, msg=''):
         self.assertExists(path, msg, os.path.lexists)
@@ -52,15 +76,33 @@ class AssertFile:
         self.assertNotExists(path, msg, os.path.lexists)
 
     def assertNotExists(self, path, msg='', func=os.path.exists):
-        if func(self.getTestPath(path)):
-            raise AssertionError(
-                'The file %s should not exist, but it does. %s' % (path, msg))
+        if func(getTestPath(path)):
+            raise AssertionError('The file %s should not exist, but it does. %s' % (path, msg))
 
     def assertCondExists(self, cond, path, msg=''):
         if cond:
             self.assertExists(path, msg)
         else:
             self.assertNotExists(path, msg)
+
+    #
+    # file creation functions
+    #
+    def write_file(self, filename, contents=''):
+        """Create a temporary file, optionally writing contents to it"""
+        if not os.path.isabs(filename):
+            filename = os.path.join(self.tempdir, filename)
+        filename = extended_path(filename)
+        with open(filename, 'w') as f:
+            f.write(contents)
+        assert (os.path.exists(filename))
+        return filename
+
+
+def getTestPath(path):
+    if 'nt' == os.name:
+        return extended_path(os.path.normpath(path))
+    return path
 
 
 def destructive_tests(title):
@@ -73,42 +115,37 @@ def destructive_tests(title):
 
 def touch_file(filename):
     """Create an empty file"""
-    write_file(filename, '')
+    with open(filename, "w") as f:
+        pass
+    import os.path
+    assert(os.path.exists(filename))
 
 
 def validate_result(self, result, really_delete=False):
     """Validate the command returned valid results"""
-    self.assert_(isinstance(result, dict), "result is a %s" % type(result))
+    self.assertIsInstance(result, dict, "result is a %s" % type(result))
     # label
-    self.assert_(isinstance(result['label'], (str, unicode)))
-    self.assert_(len(result['label'].strip()) > 0)
+    self.assertIsString(result['label'])
+    self.assertGreater(len(result['label'].strip()), 0)
     # n_*
-    self.assert_(isinstance(result['n_deleted'], (int, long)))
-    self.assert_(result['n_deleted'] >= 0)
-    self.assert_(result['n_deleted'] <= 1)
+    self.assertIsInteger(result['n_deleted'])
+    self.assertGreaterEqual(result['n_deleted'], 0)
+    self.assertLessEqual(result['n_deleted'], 1)
     self.assertEqual(result['n_special'] + result['n_deleted'], 1)
     # size
-    self.assert_(isinstance(result['size'], (int, long, type(None))),
-                 "size is %s" % str(result['size']))
+    self.assertIsInstance(result['size'], (int, long, type(None),), "size is %s" % str(result['size']))
     # path
     filename = result['path']
     if not filename:
         # the process action, for example, does not have a filename
         return
     from bleachbit import encoding
-    self.assert_(isinstance(filename, (str, unicode, type(None))),
+    self.assertIsInstance(filename, (str, unicode, type(None)),
                  "Filename is invalid: '%s' (type %s)" % (filename, type(filename)))
-    if isinstance(filename, (str, unicode)) and \
-            not filename[0:2] == 'HK':
+    if isinstance(filename, (str, unicode)) and not filename[0:2] == 'HK':
         if really_delete:
             self.assertNotLExists(filename)
         else:
             self.assertLExists(filename)
 
 
-def write_file(filename, contents):
-    """Write contents to file"""
-    with open(extended_path(filename), 'w') as f:
-        f.write(contents)
-    import os.path
-    assert(os.path.exists(extended_path(filename)))


### PR DESCRIPTION
For an eventual py3-transition we need better unit test coverage.

What's planned / done:
- [X] Introduce a custom base class with better tempfile handling and asserts
- [ ] Convert asserts / tempfile creation to use the class
- [x] Convert asserts from `self.assert_` to more meaningful asserts (especially `self.assert_(isinstance(...))`
- [ ] test for unicode / bytes explicitly