### PR TITLE
Fix bug in network share path handling

### DIFF
--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -378,7 +378,7 @@ def extended_path_undo(path):
     """"""
     if 'nt' == os.name:
         if path.startswith(r'\\?\unc'):
-            return path[7:]
+            return '\\' + path[7:]
         if path.startswith(r'\\?'):
             return path[4:]
     return path

--- a/tests/TestFileUtilities.py
+++ b/tests/TestFileUtilities.py
@@ -434,7 +434,7 @@ class FileUtilitiesTestCase(unittest.TestCase, common.AssertFile):
             tests_undo = (
                 (r'\\?\c:\windows\notepad.exe', r'c:\windows\notepad.exe'),
                 (r'c:\windows\notepad.exe', r'c:\windows\notepad.exe'),
-                (r'\\?\unc\\server\share\windows\notepad.exe', r'\\server\share\windows\notepad.exe'),
+                (r'\\?\unc\server\share\windows\notepad.exe', r'\\server\share\windows\notepad.exe'),
                 (r'\\server\share\windows\notepad.exe',
                  r'\\server\share\windows\notepad.exe')
             )


### PR DESCRIPTION
UNC paths have only one backslash before the server name.

> The "\\?\" prefix can also be used with paths constructed according to the universal naming convention (UNC). To specify such a path using UNC, use the "\\?\UNC\" prefix. For example, "\\?\UNC\server\share", where "server" is the name of the computer and "share" is the name of the shared folder. 
[source](https://msdn.microsoft.com/en-us/library/aa365247(VS.85).aspx#maxpath)