### PR TITLE
Drop RPM dependency on gnomevfs

### DIFF
--- a/bleachbit.spec
+++ b/bleachbit.spec
@@ -29,7 +29,6 @@ BuildRequires:  desktop-file-utils
 BuildRequires:  gettext
 BuildRequires:  python-devel
 Requires:       python >= 2.6
-Requires:       gnome-python2-gnomevfs
 Requires:       pygtk2 >= 2.6
 Requires:       usermode
 %endif
@@ -41,7 +40,6 @@ BuildRequires:  desktop-file-utils
 BuildRequires:  make
 BuildRequires:  python-devel
 BuildRequires:  update-desktop-files
-Requires:       python-gnome
 Requires:       python-gtk >= 2.6
 Requires:       python-xml
 %py_requires


### PR DESCRIPTION
According to 1c4a117ef2608a53001e5ecf9c9a3ce2653c38e9 and 89a7a06f6f4bfe734d3d1933058273e337669d9d the code was migrated. See also https://build.opensuse.org/request/show/509524