### PR TITLE
If user selects a single cleaner option, display action summary in right pane

### DIFF
--- a/bleachbit/Action.py
+++ b/bleachbit/Action.py
@@ -104,7 +104,8 @@ class ActionProvider:
         """Yield each command (which can be previewed or executed)"""
         pass
 
-
+    def __str__(self):
+        return self.action_key
 #
 # base class
 #
@@ -194,6 +195,21 @@ class FileActionProvider(ActionProvider):
         import itertools
         for f in itertools.ifilter(self.path_filter, self._get_paths()):
             yield f
+
+    def __str__(self):
+        ret = self.action_key+":   "
+        ret += "and   ".join(self.paths)
+        if self.regex:
+            ret += "   if   "+self.regex
+        if self.nregex:
+            ret += "   if not   "+self.nregex
+        if self.wholeregex:
+            ret += "   if whole   "+self.wholeregex
+        if self.nwholeregex:
+            ret += "   if not whole   "+self.nwholeregex
+        if self.object_type:
+            ret += "   if type   "+self.object_type
+        return ret
 
     def _get_paths(self):
         """Return a filtered list of files"""
@@ -537,6 +553,9 @@ class Winreg(ActionProvider):
 
     def get_commands(self):
         yield Command.Winreg(self.keyname, self.name)
+
+    def __str__(self):
+        return "winreg:   "+self.keyname+"   "+self.name
 
 
 class YumCleanAll(ActionProvider):

--- a/bleachbit/Cleaner.py
+++ b/bleachbit/Cleaner.py
@@ -134,6 +134,12 @@ class Cleaner:
         if self.options:
             for key in sorted(self.options.keys()):
                 yield (self.options[key][0], self.options[key][1])
+                
+    def get_long_option_description(self, key):
+        """Yield the name and a potentially more verbose description for a single option"""
+        if self.options:
+            return (self.options[key][0], self.options[key][1])
+
 
     def get_options(self):
         """Return user-configurable options in 2-tuple (id, name)"""

--- a/bleachbit/Cleaner.py
+++ b/bleachbit/Cleaner.py
@@ -138,7 +138,14 @@ class Cleaner:
     def get_long_option_description(self, key):
         """Yield the name and a potentially more verbose description for a single option"""
         if self.options:
-            return (self.options[key][0], self.options[key][1])
+            ret = self.options[key][1]
+            ret += "\n\nThis cleanup option will perform the following actions:\n\n"
+            for action in self.actions:
+                if key != action[0]: continue
+                act = action[1]
+                ret += str(act)
+                ret += "\n"
+            return (self.options[key][0], ret)
 
 
     def get_options(self):

--- a/bleachbit/GUI.py
+++ b/bleachbit/GUI.py
@@ -295,20 +295,29 @@ class GUI:
         row = paths[0]
         name = model[row][0]
         cleaner_id = model[row][2]
+        selected_option = None
+        if len(paths) > 1:
+            selected_option = model[paths][2]
         self.progressbar.hide()
-        description = backends[cleaner_id].get_description()
-        self.textbuffer.set_text("")
-        self.append_text(name + "\n", 'operation')
-        if not description:
-            description = ""
-        self.append_text(description + "\n\n\n")
-        for (label, description) in backends[cleaner_id].get_option_descriptions():
-            self.append_text(label, 'option_label')
-            if description:
-                self.append_text(': ', 'option_label')
-                self.append_text(description)
-            self.append_text("\n\n")
-
+        if selected_option is None:
+            description = backends[cleaner_id].get_description()
+            self.textbuffer.set_text("")
+            self.append_text(name + "\n", 'operation')
+            if not description:
+                description = ""
+            self.append_text(description + "\n\n\n")
+            for (label, description) in backends[cleaner_id].get_option_descriptions():
+                self.append_text(label, 'option_label')
+                if description:
+                    self.append_text(': ', 'option_label')
+                    self.append_text(description)
+                self.append_text("\n\n")
+        else:
+            label, long_description = backends[cleaner_id].get_long_option_description(selected_option)
+            self.textbuffer.set_text("")
+            self.append_text(name + " - " + label + "\n", 'operation')
+            self.append_text(long_description + "\n\n\n")
+            
     def get_selected_operations(self):
         """Return a list of the IDs of the selected operations in the tree view"""
         ret = []


### PR DESCRIPTION
Currently, there's no difference between selecting a group or selecting a single option in the left pane. These two patches change the behavior so that if a single option is selected in the left pane, then a textual description of the associated actions for that option is displayed in the right pane. This allows power users to quickly review the files or paths that a given rule will modify and is more concise than the output produced by preview.