### PR TITLE
Add OpenBSD cleaner path

### DIFF
--- a/bleachbit/__init__.py
+++ b/bleachbit/__init__.py
@@ -195,6 +195,8 @@ elif sys.platform == 'win32':
     system_cleaners_dir = os.path.join(bleachbit_exe_path, 'share\\cleaners\\')
 elif sys.platform[:6] == 'netbsd':
     system_cleaners_dir = '/usr/pkg/share/bleachbit/cleaners'
+elif sys.platform.startswith('openbsd'):
+    system_cleaners_dir = '/usr/local/share/bleachbit/cleaners'
 else:
     system_cleaners_dir = None
     logger.warning('unknown system cleaners directory for platform %s ', sys.platform)


### PR DESCRIPTION
Add a path for cleaners on OpenBSD.
Was not sure what else may be needed to be changed but this at least allows it to be installed for further testing.

Partially resolves #371 