### PR TITLE
Switch distutils for setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ import glob
 import os
 import sys
 import tempfile
-from distutils.core import setup
+from setuptools import setup
 if sys.platform == 'win32':
     try:
         import py2exe


### PR DESCRIPTION
Not sure what `distutils.core` was used for but switching this for `setuptools` seems to still work as expected. There are some missing flags with `distutils` that cause issues creating packages on some OS.

Came across this working on #371 