### PR TITLE
#!/usr/bin/env python2 instead #!/usr/bin/env python

### DIFF
--- a/bleachbit.py
+++ b/bleachbit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # vim: ts=4:sw=4:expandtab
 
 # BleachBit


### PR DESCRIPTION
Why don't use
`#!/usr/bin/env python2`

instead of 
`#!/usr/bin/env python`

we don't know the default python version in a system and as [PEP 394 ](https://www.python.org/dev/peps/pep-0394/) suggest:

* in preparation for an eventual change in the default version of Python, Python 2 only scripts should either be updated to be source compatible with Python 3 or else to use python2 in the shebang line.