### PR TITLE
Fix Windows Explorer search history cleaner on Windows 10

### DIFF
--- a/cleaners/windows_explorer.xml
+++ b/cleaners/windows_explorer.xml
@@ -75,6 +75,8 @@
     <label>Search history</label>
     <description>Delete the search history</description>
     <action command="winreg" path="HKCU\Software\Microsoft\Search Assistant\ACMru"/>
+    <!-- Windows 10 -->
+    <action command="winreg" path="HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\WordWheelQuery"/>
   </option>
   <option id="thumbnails">
     <label>Thumbnails</label>


### PR DESCRIPTION
At least on Windows 10, the "Search History" cleaner under "Windows Explorer" doesn't clear the file explorer search history. To do so, it just needs to delete an additional registry key.