### PR TITLE
Gnome notifications fix

### DIFF
--- a/bleachbit.desktop
+++ b/bleachbit.desktop
@@ -111,4 +111,4 @@ Icon=bleachbit
 Categories=GTK;System;
 Keywords=clean;performances;free;privacy;
 StartupNotify=true
-
+X-GNOME-UsesNotifications=true

--- a/bleachbit/GUI.py
+++ b/bleachbit/GUI.py
@@ -413,6 +413,10 @@ class GUI:
             if pynotify.init(APP_NAME):
                 notify = pynotify.Notification('BleachBit', _("Done."),
                                                icon='bleachbit')
+                if 'posix' == os.name and bleachbit.expanduser('~') == '/root':
+                    notify.set_hint("desktop-entry", "bleachbit-root")
+                else:
+                    notify.set_hint("desktop-entry", "bleachbit")
                 notify.show()
                 notify.set_timeout(10000)
 


### PR DESCRIPTION
Due to Gnome Guidelines https://wiki.gnome.org/Initiatives/GnomeGoals/NotificationSource

Now, due to the absence of these parameters, notifications from the bleachbit are displayed as "Others"