### PR TITLE
Improve support for FreeBSD and OpenBSD

### DIFF
--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -62,7 +62,7 @@ def open_files_linux():
 def open_files_lsof(run_lsof=None):
     if run_lsof is None:
         def run_lsof():
-            subprocess.check_output(["lsof", "-Fn", "-n"])
+            return subprocess.check_output(["lsof", "-Fn", "-n"])
     for f in run_lsof().split("\n"):
         if f.startswith("n/"):
             yield f[1:]  # Drop lsof's "n"
@@ -71,7 +71,7 @@ def open_files_lsof(run_lsof=None):
 def open_files():
     if sys.platform.startswith('linux'):
         files = open_files_linux()
-    elif 'darwin' == sys.platform:
+    elif 'darwin' == sys.platform or sys.platform.startswith('freebsd'):
         files = open_files_lsof()
     else:
         raise RuntimeError('unsupported platform for open_files()')

--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -466,7 +466,7 @@ def is_broken_xdg_desktop(pathname):
 def is_running_darwin(exename, run_ps=None):
     if run_ps is None:
         def run_ps():
-            subprocess.check_output(["ps", "aux", "-c"])
+            return subprocess.check_output(["ps", "aux", "-c"])
     try:
         processess = (re.split(r"\s+", p, 10)[10] for p in run_ps().split("\n") if p != "")
         next(processess)  # drop the header
@@ -496,7 +496,9 @@ def is_running(exename):
     """Check whether exename is running"""
     if sys.platform.startswith('linux'):
         return is_running_linux(exename)
-    elif 'darwin' == sys.platform:
+    elif ('darwin' == sys.platform or
+          sys.platform.startswith('openbsd') or
+          sys.platform.startswith('freebsd')):
         return is_running_darwin(exename)
     else:
         raise RuntimeError('unsupported platform for physical_free()')

--- a/bleachbit/__init__.py
+++ b/bleachbit/__init__.py
@@ -195,7 +195,7 @@ elif sys.platform == 'win32':
     system_cleaners_dir = os.path.join(bleachbit_exe_path, 'share\\cleaners\\')
 elif sys.platform[:6] == 'netbsd':
     system_cleaners_dir = '/usr/pkg/share/bleachbit/cleaners'
-elif sys.platform.startswith('openbsd'):
+elif sys.platform.startswith('openbsd') or sys.platform.startswith('freebsd'):
     system_cleaners_dir = '/usr/local/share/bleachbit/cleaners'
 else:
     system_cleaners_dir = None
@@ -208,10 +208,13 @@ if portable_mode:
         os.path.join(bleachbit_exe_path, '../cleaners'))
 
 # application icon
-__icons = ('/usr/share/pixmaps/bleachbit.png',  # Linux
-           os.path.join(bleachbit_exe_path, 'share\\bleachbit.png'),  # Windows
-           '/usr/pkg/share/pixmaps/bleachbit.png',  # NetBSD
-           os.path.normpath(os.path.join(bleachbit_exe_path, '../bleachbit.png')))  # local
+__icons = (
+    '/usr/share/pixmaps/bleachbit.png',  # Linux
+    os.path.join(bleachbit_exe_path, 'share\\bleachbit.png'),  # Windows
+    '/usr/pkg/share/pixmaps/bleachbit.png',  # NetBSD
+    '/usr/local/share/pixmaps/bleachbit.png',  # FreeBSD and OpenBSD
+    os.path.normpath(os.path.join(bleachbit_exe_path, '../bleachbit.png')),  # local
+)
 appicon_path = None
 for __icon in __icons:
     if os.path.exists(__icon):
@@ -230,6 +233,9 @@ else:
         locale_dir = os.path.join(bleachbit_exe_path, 'share\\locale\\')
     elif sys.platform[:6] == 'netbsd':
         locale_dir = "/usr/pkg/share/locale/"
+    elif (sys.platform.startswith('openbsd') or
+          sys.platform.startswith('freebsd')):
+        locale_dir = "/usr/local/share/locale/"
 
 
 # launcher

--- a/cleaners/chromium.xml
+++ b/cleaners/chromium.xml
@@ -25,6 +25,8 @@
   <running type="exe">chrome.exe</running>
   <!-- Fedora 14 -->
   <running type="exe">chromium-browser</running>
+  <!-- OpenBSD and FreeBSD -->
+  <running type="exe">chrome</running>
   <var name="base">
     <value>%LocalAppData%\Chromium\User Data</value>
     <value>$XDG_CONFIG_HOME/chromium</value>

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,9 @@ if sys.platform.startswith('linux'):
 elif sys.platform[:6] == 'netbsd':
     data_files.append(('/usr/pkg/share/applications', ['./bleachbit.desktop']))
     data_files.append(('/usr/pkg/share/pixmaps/', ['./bleachbit.png']))
+elif sys.platform.startswith('openbsd') or sys.platform.startswith('freebsd'):
+    data_files.append(('/usr/local/share/applications', ['./bleachbit.desktop']))
+    data_files.append(('/usr/local/share/pixmaps/', ['./bleachbit.png']))
 
 
 args = {}

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -55,6 +55,8 @@ class UnixTestCase(common.BleachbitTestCase):
             bytes_freed = apt_autoremove()
             self.assertIsInteger(bytes_freed)
 
+    @unittest.skipUnless(FileUtilities.exe_exists('apt-get'),
+                         'skipping tests for unavailable apt-get')
     def test_get_apt_size(self):
         """Unit test for method get_apt_size()"""
         size = get_apt_size()
@@ -139,7 +141,7 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
             # /usr/share/locale/en_* should be ignored
             self.assertEqual(path.find('/en_'), -1)
             counter += 1
-        self.assertGreater(counter, 0, 'Zero files deleted by localization cleaner.' +
+        self.assertGreater(counter, 0, 'Zero files deleted by localization cleaner. ' +
                                        'This may be an error unless you really deleted all the files.')
 
     def test_fakelocalizationdirs(self):

--- a/tests/TestWipe.py
+++ b/tests/TestWipe.py
@@ -124,7 +124,8 @@ def verify_cleanliness(filename):
     return clean
 
 
-@unittest.skipIf('nt' == os.name, 'test_wipe() not supported on Windows')
+@unittest.skipIf('nt' == os.name or sys.platform.startswith('freebsd'),
+                 'test_wipe() not supported on Windows or FreeBSD')
 def test_wipe_sub(n_bytes, mkfs_cmd):
     """Test FileUtilities.wipe_path"""
 


### PR DESCRIPTION
This isn't a complete solution, but it does fix some of the compatibility issues. The tests that fail on FreeBSD are ones that were already failing. Previously the results were `failures=14, errors=9, skipped=34`. Now they are `failures=12, errors=3, skipped=35`.

It also includes a fix to two of the `subprocess.check_output` calls. The existing tests don't catch the lack of return value because they stub out the function with a lambda. When I get time, I might add some checks for that.