### PR TITLE
Improve cleaner support for FreeBSD

### DIFF
--- a/bleachbit/CleanerML.py
+++ b/bleachbit/CleanerML.py
@@ -92,6 +92,8 @@ class CleanerML:
             current_os = ('bsd', 'openbsd', 'unix')
         elif platform.startswith('netbsd'):
             current_os = ('bsd', 'netbsd', 'unix')
+        elif platform.startswith('freebsd'):
+            current_os = ('bsd', 'freebsd', 'unix')
         elif platform == 'win32':
             current_os = ('windows')
         else:

--- a/cleaners/bash.xml
+++ b/cleaners/bash.xml
@@ -19,7 +19,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<cleaner id="bash" os="linux">
+<cleaner id="bash" os="unix">
   <label>Bash</label>
   <description>Shell</description>
   <option id="history">

--- a/cleaners/chromium.xml
+++ b/cleaners/chromium.xml
@@ -31,10 +31,14 @@
   <var name="base">
     <value os="windows">%LocalAppData%\Chromium\User Data</value>
     <value os="linux">$XDG_CONFIG_HOME/chromium</value>
+    <value os="freebsd">$XDG_CONFIG_HOME/chromium</value>
+    <value os="openbsd">$XDG_CONFIG_HOME/chromium</value>
   </var>
   <var name="profile">
     <value os="windows">%LocalAppData%\Chromium\User Data\Default</value>
     <value os="linux">$XDG_CONFIG_HOME/chromium/Default</value>
+    <value os="freebsd">$XDG_CONFIG_HOME/chromium/Default</value>
+    <value os="openbsd">$XDG_CONFIG_HOME/chromium/Default</value>
   </var>
   <option id="cache">
     <label>Cache</label>

--- a/cleaners/easytag.xml
+++ b/cleaners/easytag.xml
@@ -20,9 +20,10 @@
 
 -->
 <!-- FIXME: No idea if this is available for Windows. -->
-<cleaner id="easytag" os="linux">
+<cleaner id="easytag" os="unix">
   <label>EasyTAG</label>
   <description translators="This software edits metadata tags, such as title and artist, in audio files">Audio files tagger</description>
+  <running type="exe" os="freebsd">easytag</running>
   <option id="history">
     <label>History</label>
     <description>Delete the usage history</description>

--- a/cleaners/firefox.xml
+++ b/cleaners/firefox.xml
@@ -30,10 +30,14 @@
   <var name="base">
     <value os="windows">%AppData%\Mozilla\Firefox</value>
     <value os="linux">~/.mozilla/firefox</value>
+    <value os="freebsd">~/.mozilla/firefox</value>
+    <value os="openbsd">~/.mozilla/firefox</value>
   </var>
   <var name="profile">
     <value search="glob" os="windows">%AppData%\Mozilla\Firefox\Profiles\*</value>
     <value search="glob" os="linux">~/.mozilla/firefox/*</value>
+    <value search="glob" os="freebsd">~/.mozilla/firefox/*</value>
+    <value search="glob" os="openbsd">~/.mozilla/firefox/*</value>
   </var>
   <option id="backup">
     <label>Backup files</label>

--- a/cleaners/gnome.xml
+++ b/cleaners/gnome.xml
@@ -19,7 +19,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<cleaner id="gnome" os="linux">
+<cleaner id="gnome" os="unix">
   <label>GNOME</label>
   <description>Desktop environment</description>
   <option id="run">

--- a/cleaners/gwenview.xml
+++ b/cleaners/gwenview.xml
@@ -19,8 +19,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<cleaner id="gwenview" os="linux">
+<cleaner id="gwenview" os="unix">
   <label>Gwenview</label>
+  <running type="exe" os="freebsd">gwenview</running>
   <option id="recent_documents">
     <label>Recent documents list</label>
     <description>Delete the list of recently used documents</description>
@@ -30,5 +31,7 @@
     <!-- Fedora 11 KDE 4.3.1 has ~/.kde/ -->
     <action command="delete" search="glob" path="~/.kde/share/apps/gwenview/recentfolders/*rc"/>
     <action command="delete" search="glob" path="~/.kde/share/apps/gwenview/recenturls/*rc"/>
+    <!-- FreeBSD -->
+    <action command="delete" search="glob" path="$XDG_DATA_HOME/gwenview/recentfolders/*rc"/>
   </option>
 </cleaner>

--- a/cleaners/libreoffice.xml
+++ b/cleaners/libreoffice.xml
@@ -23,12 +23,14 @@
   <label>LibreOffice</label>
   <description>Office suite</description>
   <running type="exe" os="linux">soffice.bin</running>
+  <running type="exe" os="freebsd">soffice.bin</running>
   <running type="exe" os="windows">soffice.exe</running>
   <option id="cache">
     <label>Cache</label>
     <description>Delete the cache</description>
     <action command="delete" search="walk.all" path="$APPDATA\.libreoffice\3\user\uno_packages\cache\"/>
     <action command="delete" search="walk.all" path="$XDG_CONFIG_HOME/libreoffice/3/user/uno_packages/cache/"/>
+    <action command="delete" search="walk.all" path="$XDG_CONFIG_HOME/libreoffice/4/user/uno_packages/cache/"/>
     <action command="delete" search="walk.all" path="~/.libreoffice/3/user/uno_packages/cache/"/>
     <action command="delete" search="walk.all" path="~/.libreoffice/3-suse/user/config/uno_packages/cache/"/>
   </option>

--- a/cleaners/sqlite3.xml
+++ b/cleaners/sqlite3.xml
@@ -21,7 +21,7 @@
 -->
 <!-- verified with SQLite version 3.7.13 on Ubuntu 12.10 -->
 <!-- verified with SQLite version 3.11.0 on Ubuntu 16.04 -->
-<cleaner id="sqlite3" os="linux">
+<cleaner id="sqlite3" os="unix">
   <label>sqlite3</label>
   <option id="history">
     <label>History</label>

--- a/cleaners/thumbnails.xml
+++ b/cleaners/thumbnails.xml
@@ -19,7 +19,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
-<cleaner id="thumbnails" os="linux">
+<cleaner id="thumbnails" os="unix">
   <label translate="true">Thumbnails</label>
   <description>Icons for files on the system</description>
   <option id="cache">

--- a/cleaners/thunderbird.xml
+++ b/cleaners/thunderbird.xml
@@ -24,6 +24,7 @@
   <description>Email client</description>
   <running type="exe" os="windows">thunderbird.exe</running>
   <running type="exe" os="linux">thunderbird-bin</running>
+  <running type="exe" os="freebsd">thunderbird</running>
   <option id="cache">
     <label>Cache</label>
     <description>Delete the web cache, which reduces time to display revisited pages</description>

--- a/doc/cleaner_markup_language.xsd
+++ b/doc/cleaner_markup_language.xsd
@@ -29,6 +29,7 @@
           <xs:enumeration value="linux"/>
           <xs:enumeration value="netbsd"/>
           <xs:enumeration value="openbsd"/>
+          <xs:enumeration value="freebsd"/>
           <xs:enumeration value="unix"/>
           <xs:enumeration value="windows"/>
         </xs:restriction>


### PR DESCRIPTION
The `os` option in CleanerML works quite well, but it disabled quite a few of the cleaners that work on FreeBSD. I've re-enabled the cleaners that I've tested on FreeBSD, and added some missing paths.

The results of running the test suite are unchanged: `failures=12, errors=3, skipped=35`