### PR TITLE
Add ~/.local/share/mc to profile

### DIFF
--- a/cleaners/mc.xml
+++ b/cleaners/mc.xml
@@ -37,6 +37,7 @@
   <var name="profile">
     <value os="windows">%UserProfile%\Midnight Commander</value>
     <value os="linux">~/.mc</value>
+    <value os="linux">~/.local/share/mc</value>
   </var>
   <option id="history">
     <label>History</label>


### PR DESCRIPTION
It would seem that if your history is in ~/.local/share/mc this cleaner doesn't wipe that. This PR fixes that.