### PR TITLE
Switch from os.walk to scandir.walk to improve performance

### DIFF
--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -43,6 +43,8 @@ import subprocess
 import tempfile
 import time
 
+import scandir
+
 logger = logging.getLogger(__name__)
 
 if 'nt' == os.name:
@@ -164,7 +166,7 @@ def children_in_directory(top, list_directories=False):
             for pathname in children_in_directory(top_, list_directories):
                 yield pathname
         return
-    for (dirpath, dirnames, filenames) in os.walk(top, topdown=False):
+    for (dirpath, dirnames, filenames) in scandir.walk(top, topdown=False):
         if list_directories:
             for dirname in dirnames:
                 yield os.path.join(dirpath, dirname)


### PR DESCRIPTION
Resolves #512:

python 2.7 using `os.walk`:
```bash
$ time python bleachbit/CLI.py -p vuze.cache3
Disk space to be recovered: 0
Files to be deleted: 0

real	0m50,547s
user	0m0,834s
sys	0m0,929s
```

and using `scandir.walk`:
```bash
$ time python bleachbit/CLI.py -p vuze.cache3
Disk space to be recovered: 0
Files to be deleted: 0

real	0m0,755s
user	0m0,423s
sys	0m0,068s
```
tests ran on a VM@hdd with a flushed kernel cache on a flat directory with 20k files. The start time of bleachbit includes eager loading of all the rules, so if that was excluded, the performance boost would be even more profound.

**Before this is merged, a depedency from [scandir](https://pypi.org/project/scandir/) has to be added to the project.**