### PR TITLE
Fix #318

### DIFF
--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -168,8 +168,6 @@ class Winapp:
             content = fp.read().decode('utf-8-sig').encode('utf8')
             self.parser.readfp(StringIO.StringIO(content))
 
-        #self.parser.read(pathname)
-
         self.re_detect = re.compile(r'^detect(\d+)?$')
         self.re_detectfile = re.compile(r'^detectfile(\d+)?$')
         self.re_excludekey = re.compile(r'^excludekey\d+$')

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -30,6 +30,7 @@ import os
 import glob
 import re
 from xml.dom.minidom import parseString
+import StringIO
 
 import bleachbit
 from bleachbit import Cleaner, Windows
@@ -160,8 +161,15 @@ class Winapp:
         for langsecref in set(langsecref_map.values()):
             self.add_section(langsecref[0], langsecref[1])
         self.errors = 0
+
         self.parser = bleachbit.RawConfigParser()
-        self.parser.read(pathname)
+
+        with open(pathname, 'rb') as fp:
+            content = fp.read().decode('utf-8-sig').encode('utf8')
+            self.parser.readfp(StringIO.StringIO(content))
+
+        #self.parser.read(pathname)
+
         self.re_detect = re.compile(r'^detect(\d+)?$')
         self.re_detectfile = re.compile(r'^detectfile(\d+)?$')
         self.re_excludekey = re.compile(r'^excludekey\d+$')

--- a/tests/common.py
+++ b/tests/common.py
@@ -159,7 +159,9 @@ def skipUnlessWindows(f):
     Not compatible at the class level"""
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
-        return unittest.skipUnless('win32' == sys.platform, 'not running on Windows')
+        if sys.platform != 'win32':
+            return unittest.skipUnless('win32' == sys.platform, 'not running on Windows')
+        return f(*args, **kwargs)
     return wrapper
 
 


### PR DESCRIPTION
Here I fixed only the case of the utf8 BOM. If the ini has different BOM we will crash as before. So, please tell me if we need to support more BOM options.

Also as part of this fix I fixed the common.skipUnlessWindows decorator as it hadn't worked correctly. The tests decorated with it had seemed to pass but they hadn't been called at all.