### PR TITLE
Fix "Make Chaff" in frozen (py2exe'd) version

### DIFF
--- a/bleachbit/Chaff.py
+++ b/bleachbit/Chaff.py
@@ -28,17 +28,11 @@ import random
 import tempfile
 from datetime import datetime, timedelta
 
-try:
-    import certifi
-except:
-    HAVE_CERTIFI = False
-else:
-    HAVE_CERTIFI = True
-
 from bleachbit import _
 from bleachbit import options_dir
+from bleachbit import CA_BUNDLE
 
-import markovify
+from . import markovify
 
 logger = logging.getLogger(__name__)
 
@@ -126,10 +120,6 @@ def download_models(content_model_path=DEFAULT_CONTENT_MODEL_PATH,
     from urllib2 import urlopen, URLError, HTTPError
     from httplib import HTTPException
     import socket
-    if HAVE_CERTIFI:
-        cafile = certifi.where()
-    else:
-        cafile = None
     for (url, fn) in ((URL_CLINTON_SUBJECT, subject_model_path),
                       (URL_CLINTON_CONTENT, content_model_path),
                       (URL_2600, twentysixhundred_model_path)):
@@ -138,7 +128,7 @@ def download_models(content_model_path=DEFAULT_CONTENT_MODEL_PATH,
             continue
         logger.info('Downloading %s to %s', url, fn)
         try:
-            resp = urlopen(url, cafile=cafile)
+            resp = urlopen(url, cafile=CA_BUNDLE)
             with open(fn, 'wb') as f:
                 f.write(resp.read())
         except (URLError, HTTPError, HTTPException, socket.error) as exc:

--- a/bleachbit/__init__.py
+++ b/bleachbit/__init__.py
@@ -62,9 +62,12 @@ bleachbit_exe_path = None
 if hasattr(sys, 'frozen'):
     # running frozen in py2exe
     bleachbit_exe_path = os.path.dirname(sys.executable.decode(sys.getfilesystemencoding()))
+    CA_BUNDLE = os.path.join(bleachbit_exe_path, 'cacert.pem')
 else:
     # __file__ is absolute path to __init__.py
     bleachbit_exe_path = os.path.dirname(os.path.dirname(__file__.decode(sys.getfilesystemencoding())))
+    import certifi
+    CA_BUNDLE = certifi.where()
 
 # license
 license_filename = None

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ if 'py2exe' in sys.argv:
             'packages': ['encodings', 'gi'],
             'optimize': 2,  # extra optimization (like python -OO)
             'includes': ['gi'],
-            'excludes': ['pyreadline', 'difflib', 'doctest',
+            'excludes': ['certifi', 'pyreadline', 'difflib', 'doctest',
                          'pickle', 'ftplib', 'bleachbit.Unix'],
             'dll_excludes': [
                 'libgstreamer-1.0-0.dll',
@@ -252,7 +252,7 @@ def run_setup():
           license="GPLv3",
           url=bleachbit.APP_URL,
           platforms='Linux and Windows; Python v2.6 and 2.7; GTK v3.12+',
-          packages=['bleachbit'],
+          packages=['bleachbit', 'bleachbit.markovify'],
           **args)
 
 

--- a/windows/setup_py2exe.py
+++ b/windows/setup_py2exe.py
@@ -24,6 +24,7 @@ import os
 import shutil
 import subprocess
 import sys
+import certifi
 
 logger = logging.getLogger('setup_py2exe')
 logger.setLevel(logging.INFO)
@@ -216,14 +217,20 @@ def build():
     logger.info('Copying GTK files and icon')
     copytree(GTK_DIR + '\\etc', 'dist\\etc')
     copytree(GTK_DIR + '\\lib', 'dist\\lib')
-    for subpath in ['glib-2.0', 'fontconfig', 'fonts', 'icons', 'themes']:
+    for subpath in ['fontconfig', 'fonts', 'icons', 'themes']:
         copytree(os.path.join(GTK_DIR, 'share', subpath), 'dist\\share\\' + subpath)
+    SCHEMAS_DIR = 'share\\glib-2.0\\schemas'
+    os.makedirs(os.path.join('dist', SCHEMAS_DIR))
+    shutil.copyfile(os.path.join(GTK_DIR, SCHEMAS_DIR, 'gschemas.compiled'), os.path.join('dist', SCHEMAS_DIR, 'gschemas.compiled'))
     shutil.copyfile('bleachbit.png',  'dist\\share\\bleachbit.png')
     for dll in glob.glob1(GTK_DIR, '*.dll'):
         shutil.copyfile(os.path.join(GTK_DIR,dll), 'dist\\'+dll)
 
     os.mkdir('dist\\data')
     shutil.copyfile('data\\app-menu.ui', 'dist\\data\\app-menu.ui')
+
+    logger.info('Copying CA bundle')
+    shutil.copyfile(certifi.where(), os.path.join('dist', 'cacert.pem'))
 
     logger.info('Copying BleachBit localizations')
     shutil.rmtree('dist\\share\\locale', ignore_errors=True)
@@ -265,7 +272,6 @@ def delete_unnecessary():
         r'share\themes\default',
         r'share\themes\emacs',
         r'share\fontconfig',
-        r'share\glib-2.0',
         r'share\icons\highcontrast',
         r'share\themes',
         r'win32evtlog.pyd',


### PR DESCRIPTION
- py2exe does not copy certifi/cacert.pem - copy it manually and do not
use certifi in frozen version
- use relative import for markovify so that py2exe gets absolute name
(bleachbit.markovify) correctly
- include bleachbit.markovify into the build
- include glib-2.0/schemas/gschemas.compiled so that "Make Chaff" dialog
window can be created

Fixes #614
Fixes #615