### PR TITLE
Override os.path.islink() so that os.walk() does not recurse into junctions on Windows

### DIFF
--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -33,7 +33,7 @@ import errno
 import glob
 import locale
 import logging
-import os
+import os, os.path
 import random
 import re
 import stat
@@ -48,6 +48,9 @@ logger = logging.getLogger(__name__)
 if 'nt' == os.name:
     from pywintypes import error as pywinerror
     import win32file
+    import bleachbit.Windows
+    os_path_islink = os.path.islink
+    os.path.islink = lambda path: os_path_islink(path) or bleachbit.Windows.is_junction(path)
 
 if 'posix' == os.name:
     from bleachbit.General import WindowsError

--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -58,6 +58,16 @@ if 'posix' == os.name:
 
 try:
     from scandir import walk
+    if 'nt' == os.name:
+        import scandir
+        import bleachbit.Windows
+
+        class _Win32DirEntryPython(scandir.Win32DirEntryPython):
+            def is_symlink(self):
+                return super(_Win32DirEntryPython, self).is_symlink() or bleachbit.Windows.is_junction(self.path)
+
+        scandir.scandir = scandir.scandir_python
+        scandir.DirEntry = scandir.Win32DirEntryPython = _Win32DirEntryPython
 except ImportError:
     logger.warning('scandir is not available, so falling back to slower os.walk()')
     from os import walk

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -236,7 +236,10 @@ def delete_updates():
 
 def detect_registry_key(parent_key):
     """Detect whether registry key exists"""
-    parent_key = str(parent_key)  # Unicode to byte string
+    try:
+        parent_key = str(parent_key)  # Unicode to byte string
+    except UnicodeEncodeError:
+        return False
     (hive, parent_sub_key) = split_registry_key(parent_key)
     hkey = None
     try:
@@ -443,7 +446,10 @@ def is_junction(path):
     so this is needed
     """
     FILE_ATTRIBUTE_REPARSE_POINT = 0x400
-    attr = windll.kernel32.GetFileAttributesW(unicode(path))
+    if isinstance(path, unicode):
+        attr = windll.kernel32.GetFileAttributesW(path)
+    else:
+        attr = windll.kernel32.GetFileAttributesA(path)
     return bool(attr & FILE_ATTRIBUTE_REPARSE_POINT)
 
 

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -422,11 +422,10 @@ def get_recycle_bin():
     for item in h:
         path = h.GetDisplayNameOf(item, shellcon.SHGDN_FORPARSING)
         if os.path.isdir(path):
-            if not is_link(path):
-                # Return the contents of a normal directory, but do
-                # not recurse Windows symlinks in the Recycle Bin.
-                for child in FileUtilities.children_in_directory(path, True):
-                    yield child
+            # Return the contents of a normal directory, but do
+            # not recurse Windows symlinks in the Recycle Bin.
+            for child in FileUtilities.children_in_directory(path, True):
+                yield child
         yield path
 
 
@@ -437,7 +436,7 @@ def get_windows_version():
     return Decimal(vstr)
 
 
-def is_link(path):
+def is_junction(path):
     """Check whether the path is a link
 
     On Python 2.7 the function os.path.islink() always returns False,

--- a/tests/TestWindows.py
+++ b/tests/TestWindows.py
@@ -87,7 +87,7 @@ class WindowsTestCase(common.BleachbitTestCase):
             self.fail('recycle bin should be empty, but it is not')
 
     def _test_link_helper(self, mklink_option, clear_recycle_bin):
-        """Helper function for testing for links with is_link() and
+        """Helper function for testing for links with is_junction() and
         get_recycle_bin()
 
         It gets called four times for the combinations of the two
@@ -107,19 +107,19 @@ class WindowsTestCase(common.BleachbitTestCase):
         target_dir = os.path.join(self.tempdir, 'target_dir')
         os.mkdir(target_dir)
         self.assertExists(target_dir)
-        self.assertFalse(is_link(target_dir))
+        self.assertFalse(is_junction(target_dir))
 
         from random import randint
         canary_fn = os.path.join(target_dir, 'do_not_delete%d' % randint(1000,9999))
         common.touch_file(canary_fn)
         self.assertExists(canary_fn)
-        self.assertFalse(is_link(canary_fn))
+        self.assertFalse(is_junction(canary_fn))
 
         # make a normal directory to hold a link
         container_dir = os.path.join(self.tempdir, 'container_dir')
         os.mkdir(container_dir)
         self.assertExists(container_dir)
-        self.assertFalse(is_link(container_dir))
+        self.assertFalse(is_junction(container_dir))
 
         # create the link
         link_pathname = os.path.join(container_dir, 'link')
@@ -128,7 +128,7 @@ class WindowsTestCase(common.BleachbitTestCase):
         (rc, stdout, stderr) = run_external(args)
         self.assertEqual(rc, 0, stderr)
         self.assertExists(link_pathname)
-        self.assertTrue(is_link(link_pathname))
+        self.assertTrue(is_junction(link_pathname))
 
         # put the link in the recycle bin
         move_to_recycle_bin(container_dir)


### PR DESCRIPTION
Fixes #668