### PR TITLE
Python 3: Fix OBS builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ INSTALL = install
 INSTALL_DATA = $(INSTALL) -m 644
 
 # if not specified, do not check coverage
-COVERAGE ?= python3
+PYTHON ?= python3
+COVERAGE ?= $(PYTHON)
 
 build:
 	echo Nothing to build
@@ -56,8 +57,8 @@ install:
 	$(INSTALL_DATA) bleachbit/markovify/*.py $(DESTDIR)$(datadir)/bleachbit/markovify
 	#note: compileall is recursive
 	cd $(DESTDIR)$(datadir)/bleachbit && \
-	python3 -O -c "import compileall; compileall.compile_dir('.')" && \
-	python3 -c "import compileall; compileall.compile_dir('.')"
+	$(PYTHON) -O -c "import compileall; compileall.compile_dir('.')" && \
+	$(PYTHON) -c "import compileall; compileall.compile_dir('.')"
 
 	# cleaners
 	mkdir -p $(DESTDIR)$(datadir)/bleachbit/cleaners

--- a/bleachbit.spec
+++ b/bleachbit.spec
@@ -2,19 +2,10 @@
 # to build packages for CentOS, Fedora, and OpenSUSE.
 
 # The minimum supported Fedora version is now Fedora 30.
-# CentOS 7 is supported but CentOS 8 is not because it lacks Python 2.
 
 %if 0%{?fedora}
 # Example definition of variable "fedora" on Fedora 31 is "31"
 %{!?fedora_version: %define fedora_version %fedora}
-%endif
-
-%if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
-%{!?python3_sitelib: %define python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
-%endif
-
-%if 0%{?suse_version}
-%define python3_sitelib %py3_sitedir
 %endif
 
 Name:           bleachbit
@@ -33,7 +24,11 @@ BuildArch:      noarch
 %if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
 BuildRequires:  desktop-file-utils
 BuildRequires:  gettext
-BuildRequires:  python3-devel
+%if 0%{?centos_version}
+%if 0%{?centos_version} < 800
+BuildRequires:  python3-rpm-macros
+%endif
+%endif
 BuildRequires:  python3-setuptools
 Requires:       python3
 Requires:       gtk3
@@ -57,6 +52,7 @@ BuildRequires:  hostname
 BuildRequires:  desktop-file-utils
 %endif
 BuildRequires:  make
+BuildRequires:  python-rpm-macros
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 BuildRequires:  update-desktop-files
@@ -66,7 +62,7 @@ Requires:       python3-xml
 Requires:       python3-scandir
 Requires:       python3-chardet
 Requires:       python3-gobject
-%py3_requires
+#%py3_requires
 %if 0%{?suse_version} >= 1030
 Requires:       xdg-utils
 %endif
@@ -118,7 +114,7 @@ make delete_windows_files
 %install
 rm -rf $RPM_BUILD_ROOT
 
-make install DESTDIR=$RPM_BUILD_ROOT prefix=%{_prefix}
+make install PYTHON=%{__python3} DESTDIR=$RPM_BUILD_ROOT prefix=%{_prefix}
 
 %if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
 desktop-file-validate %{buildroot}/%{_datadir}/applications/org.bleachbit.BleachBit.desktop

--- a/debian/bleachbit.dsc
+++ b/debian/bleachbit.dsc
@@ -7,7 +7,7 @@ Maintainer: Andrew Ziem <andrew@bleachbit.org>
 Homepage: https://www.bleachbit.org
 Standards-Version: 3.7.3
 Build-Depends: debhelper (>= 4)
-Build-Depends-Indep: python (>= 2.6), gettext, desktop-file-utils
+Build-Depends-Indep: python3, gettext, desktop-file-utils
 Files:
  28528d402964e74dc2da424a9279827e 24376 bleachbit_3.1.0.orig.tar.gz
  64514267a04d925d9a4e4d8499328b07 1150 bleachbit_3.1.0-1.diff.gz


### PR DESCRIPTION
- RHEL6, CentOS 6 and SLE11 are not supported (do not have python3)
- RHEL7 has python3 but in rhel-7-server-beta-rpms and rhel-7-server-rpms repos which do not seem to be enabled in OBS

Other than that all other packages are now built properly.