### PR TITLE
Fix float array index in check_mapped_bit()

### DIFF
--- a/bleachbit/WindowsWipe.py
+++ b/bleachbit/WindowsWipe.py
@@ -399,7 +399,7 @@ def spike_cluster(volume_handle, cluster, tmp_file_path):
 # should look.
 def check_mapped_bit(volume_bitmap, lcn):
     assert isinstance(lcn, int)
-    mapped_bit = ord(volume_bitmap[lcn / 8])
+    mapped_bit = ord(volume_bitmap[lcn // 8])
     bit_location = lcn % 8    # zero-based
     if bit_location > 0:
         mapped_bit = mapped_bit >> bit_location


### PR DESCRIPTION
Traceback (most recent call last):
  File "C:\Users\Max\work\bleachbit\bleachbit\Worker.py", line 87, in execute
    for ret in cmd.execute(self.really_delete):
  File "C:\Users\Max\work\bleachbit\bleachbit\Command.py", line 82, in execute
    FileUtilities.delete(self.path, self.shred)
  File "C:\Users\Max\work\bleachbit\bleachbit\FileUtilities.py", line 349, in delete
    wipe_contents(path)
  File "C:\Users\Max\work\bleachbit\bleachbit\FileUtilities.py", line 784, in wipe_contents
    file_wipe(path)
  File "C:\Users\Max\work\bleachbit\bleachbit\WindowsWipe.py", line 953, in file_wipe
    orig_extents)
  File "C:\Users\Max\work\bleachbit\bleachbit\WindowsWipe.py", line 714, in poll_clusters_freed
    orig_extents, volume_bitmap)
  File "C:\Users\Max\work\bleachbit\bleachbit\WindowsWipe.py", line 326, in check_extents
    if check_mapped_bit(volume_bitmap, cluster):
  File "C:\Users\Max\work\bleachbit\bleachbit\WindowsWipe.py", line 402, in check_mapped_bit
    mapped_bit = ord(volume_bitmap[lcn / 8])
TypeError: byte indices must be integers, not float