### PR TITLE
file_wipe(): open files with FILE_FLAG_BACKUP_SEMANTICS to skip DACL checks

### DIFF
--- a/bleachbit/GUI.py
+++ b/bleachbit/GUI.py
@@ -116,7 +116,7 @@ class Bleachbit(Gtk.Application):
     _auto_exit = False
 
     def __init__(self, uac=True, shred_paths=None, auto_exit=False):
-        if uac and os.name == 'nt' and Windows.elevate_privileges():
+        if os.name == 'nt' and Windows.elevate_privileges(uac):
             # privileges escalated in other process
             sys.exit(0)
         Gtk.Application.__init__(

--- a/bleachbit/WindowsWipe.py
+++ b/bleachbit/WindowsWipe.py
@@ -108,7 +108,7 @@ from winioctlcon import (FSCTL_GET_RETRIEVAL_POINTERS,
                          FSCTL_SET_ZERO_DATA)
 from win32file import (GENERIC_READ, GENERIC_WRITE, FILE_BEGIN,
                        FILE_SHARE_READ, FILE_SHARE_WRITE,
-                       OPEN_EXISTING, CREATE_ALWAYS,
+                       OPEN_EXISTING, CREATE_ALWAYS, FILE_FLAG_BACKUP_SEMANTICS,
                        DRIVE_REMOTE, DRIVE_CDROM, DRIVE_UNKNOWN)
 from win32con import (FILE_ATTRIBUTE_ENCRYPTED,
                       FILE_ATTRIBUTE_COMPRESSED,
@@ -432,7 +432,7 @@ def determine_win_version():
 # CreateFileW gives us Unicode support.
 def open_file(file_name, mode=GENERIC_READ):
     file_handle = CreateFileW(file_name, mode, 0, None,
-                              OPEN_EXISTING, 0, None)
+                              OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, None)
     return file_handle
 
 


### PR DESCRIPTION
Fixes #337