### PR TITLE
Fix "Shred Settings and Quit"

### DIFF
--- a/bleachbit/Options.py
+++ b/bleachbit/Options.py
@@ -70,6 +70,8 @@ def path_to_option(pathname):
 
 def init_configuration():
     """Initialize an empty configuration, if necessary"""
+    if not os.path.exists(bleachbit.options_dir):
+        General.makedirs(bleachbit.options_dir)
     if os.path.lexists(bleachbit.options_file):
         logger.debug('Deleting configuration: %s ' % bleachbit.options_file)
         os.remove(bleachbit.options_file)


### PR DESCRIPTION
- shred_paths(): worker generator should be added using default priority.
Using Glib.PRIORITY_LOW causes quit() called befpre worker cleaner on
exit when "Shred Settings and Quit" is used
- property rebuild minimal bleachbit.ini after shredding is done, not before

Fixes #881