### PR TITLE
Fix wipe_path.temporaryfile() on Windows

### DIFF
--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -863,7 +863,7 @@ def wipe_path(pathname, idle=False):
     def temporaryfile():
         # reference
         # http://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits
-        maxlen = 245
+        maxlen = 185
         f = None
         while True:
             try:
@@ -875,11 +875,12 @@ def wipe_path(pathname, idle=False):
                     delete, f.name, allow_shred=False, ignore_missing=True)
                 break
             except OSError as e:
-                if e.errno in (errno.ENAMETOOLONG, errno.ENOSPC, errno.ENOENT):
+                if e.errno in (errno.ENAMETOOLONG, errno.ENOSPC, errno.ENOENT, errno.EINVAL):
                     # ext3 on Linux 3.5 returns ENOSPC if the full path is greater than 264.
                     # Shrinking the size helps.
 
                     # Microsoft Windows returns ENOENT "No such file or directory"
+                    # or EINVAL "Invalid argument"
                     # when the path is too long such as %TEMP% but not in C:\
                     if maxlen > 5:
                         maxlen -= 5

--- a/tests/TestFileUtilities.py
+++ b/tests/TestFileUtilities.py
@@ -943,6 +943,9 @@ class FileUtilitiesTestCase(common.BleachbitTestCase):
             # no idle handler
             pass
 
+    def test_wipe_path_fast(self):
+        next(wipe_path(self.tempdir, True))
+
     def test_vacuum_sqlite3(self):
         """Unit test for method vacuum_sqlite3()"""
         import sqlite3


### PR DESCRIPTION
Fixes #899, #906