### PR TITLE
Fix #915 - missing `show_uri_on_window` on Ubuntu 16.04

### DIFF
--- a/bleachbit/GuiBasic.py
+++ b/bleachbit/GuiBasic.py
@@ -193,5 +193,8 @@ def open_url(url, parent_window=None, prompt=True):
         # handling this file'
         import webbrowser
         webbrowser.open(url)
+    elif (Gtk.get_major_version(), Gtk.get_minor_version()) < (3, 22):
+        # Ubuntu 16.04 LTS ships with GTK 3.18
+        Gtk.show_uri(None, url, Gdk.CURRENT_TIME)
     else:
         Gtk.show_uri_on_window(parent_window, url, Gdk.CURRENT_TIME)


### PR DESCRIPTION
Comparing GTK 3.18
https://developer.gnome.org/gtk3/3.18/gtk3-Filesystem-utilities.html#gtk-show-uri
GTK 3.22
https://developer.gnome.org/gtk3/stable/gtk3-Filesystem-utilities.html#gtk-show-uri-on-window