### PR TITLE
Fixing Ubuntu 20.10 build on OBS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ jobs:
       python: 3.6
     - dist: bionic
       python: 3.7
+   # Ubuntu 20.04 LTS (Focal)
+    - dist: focal
+      python: 3.8
 cache: pip
 before_install:
   - python --version # show Python version

--- a/debian/README.md
+++ b/debian/README.md
@@ -17,9 +17,35 @@ login is required).
 `osc` command is used to checkout send files to OBS server,
 which automatically starts a build on new commits.
 
-Checkout files from OBS and compare to files in this directory.
+**Checkout files from OBS** and **compare** to this directory.
 ```
 osc checkout home:andrew_z bleachbit -o /tmp/obsfiles
 diff -u3 /tmp/obsfiles .
 ```
 The syntax is `osc co <project> <package> --outdir <path>`.
+
+**Branch/fork OBS package** to build on OBS service from
+your project.
+```
+$ osc branch home:andrew_z bleachbit
+A working copy of the branched package can be checked out with:
+
+osc co home:abitrolly:branches:home:andrew_z/bleachbit
+```
+
+**Inspect build status** with `osc results` and `osc buildlog`.
+```
+$ osc results
+xUbuntu_20.10        x86_64     failed
+xUbuntu_20.04        x86_64     succeeded*
+xUbuntu_18.04        x86_64     succeeded*
+...
+$ osc buildlod xUbuntu_20.10
+...
+
+[   97s] [   83.277694] reboot: Power down
+[   97s] ### VM INTERACTION END ###
+[   97s]
+[   97s] cloud132 failed "build bleachbit.dsc" at Sat Nov 28 17:44:06 UTC 2020.
+[   97s]
+```

--- a/debian/README.md
+++ b/debian/README.md
@@ -17,7 +17,9 @@ login is required).
 `osc` command is used to checkout send files to OBS server,
 which automatically starts a build on new commits.
 
+Checkout files from OBS and compare to files in this directory.
 ```
-osc checkout home:andrew_z
-cd home:andrew_z
+osc checkout home:andrew_z bleachbit -o /tmp/obsfiles
+diff -u3 /tmp/obsfiles .
 ```
+The syntax is `osc co <project> <package> --outdir <path>`.

--- a/debian/README.md
+++ b/debian/README.md
@@ -24,6 +24,14 @@ diff -u3 /tmp/obsfiles .
 ```
 Checkout syntax is `osc co <project> <package> --outdir <path>`.
 
+###### Make a local build
+From the `osc` checkout execute
+```bash
+osc build xUbuntu_20.10
+```
+where `xUbuntu_20.10` is a custom name for one of the configured
+repositories.
+
 ##### Branch/fork OBS package for testing builds on OBS
 ```bash
 $ osc branch home:andrew_z bleachbit

--- a/debian/README.md
+++ b/debian/README.md
@@ -14,27 +14,26 @@ Then create account on https://build.opensuse.org/ (see
 https://github.com/openSUSE/osc/issues/812 for discussion why
 login is required).
 
-`osc` command is used to checkout send files to OBS server,
-which automatically starts a build on new commits.
+`osc` command is used to checkout and send files to OBS server,
+which automatically starts a build on new commit.
 
-**Checkout files from OBS** and **compare** to this directory.
-```
+##### Checkout files from OBS and compare to this directory
+```bash
 osc checkout home:andrew_z bleachbit -o /tmp/obsfiles
 diff -u3 /tmp/obsfiles .
 ```
-The syntax is `osc co <project> <package> --outdir <path>`.
+Checkout syntax is `osc co <project> <package> --outdir <path>`.
 
-**Branch/fork OBS package** to build on OBS service from
-your project.
-```
+##### Branch/fork OBS package for testing builds on OBS
+```bash
 $ osc branch home:andrew_z bleachbit
 A working copy of the branched package can be checked out with:
 
 osc co home:abitrolly:branches:home:andrew_z/bleachbit
 ```
 
-**Inspect build status** with `osc results` and `osc buildlog`.
-```
+##### Inspect build status with `osc results` and `osc buildlog`
+```bash
 $ osc results
 xUbuntu_20.10        x86_64     failed
 xUbuntu_20.04        x86_64     succeeded*
@@ -49,3 +48,6 @@ $ osc buildlod xUbuntu_20.10
 [   97s] cloud132 failed "build bleachbit.dsc" at Sat Nov 28 17:44:06 UTC 2020.
 [   97s]
 ```
+
+More commands in
+[`osc` cheatsheet](https://en.opensuse.org/images/d/df/Obs-cheat-sheet.pdf)

--- a/debian/README.md
+++ b/debian/README.md
@@ -1,0 +1,3 @@
+This dir contains Debian packaging files in OBS format.
+
+https://en.opensuse.org/openSUSE:Build_Service_Debian_builds

--- a/debian/README.md
+++ b/debian/README.md
@@ -1,3 +1,23 @@
-This dir contains Debian packaging files in OBS format.
+This dir mirrors files for building various BleachBit packages
+using Open Build Service (OBS).
 
 https://en.opensuse.org/openSUSE:Build_Service_Debian_builds
+
+The OBS project page with build status and packages.
+
+https://build.opensuse.org/package/show/home:andrew_z/bleachbit
+
+### Building BleachBit package for Debian/Ubuntu
+
+First install [`osc`](https://github.com/openSUSE/osc) tool.
+Then create account on https://build.opensuse.org/ (see
+https://github.com/openSUSE/osc/issues/812 for discussion why
+login is required).
+
+`osc` command is used to checkout send files to OBS server,
+which automatically starts a build on new commits.
+
+```
+osc checkout home:andrew_z
+cd home:andrew_z
+```

--- a/debian/bleachbit.dsc
+++ b/debian/bleachbit.dsc
@@ -2,7 +2,7 @@ Format: 1.0
 Source: bleachbit
 Binary: bleachbit
 Architecture: all
-Version: 4.1.1
+Version: 4.1.1-0
 Maintainer: Andrew Ziem <andrew@bleachbit.org>
 Homepage: https://www.bleachbit.org
 Standards-Version: 3.7.3

--- a/debian/debian.changelog
+++ b/debian/debian.changelog
@@ -1,7 +1,6 @@
-bleachbit (4.1.1-1) stable; urgency=low
+bleachbit (4.1.1) stable; urgency=low
 
   * Upgrade to 4.1.1
 
-
- -- Andrew Ziem <andrew@bleachbit.org> Sun, 19 Apr 2020 14:59:46 +0000
+ -- Andrew Ziem <andrew@bleachbit.org>  Sun, 19 Apr 2020 14:59:46 +0000
 

--- a/debian/debian.control
+++ b/debian/debian.control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: Andrew Ziem <andrew@bleachbit.org>
 Build-Depends: debhelper (>= 4.1.16), python3, desktop-file-utils
 Homepage: https://www.bleachbit.org
+Vcs-Git: https://github.com/bleachbit/bleachbit
 Standards-Version: 3.7.3
 
 Package: bleachbit


### PR DESCRIPTION
This will fix #1044 once ready.

Travis doesn't support 20.10 builds, but 20.04 could be tested.

* Add Ubuntu 20.04 to CI with Python 3.8 (default)
https://wiki.ubuntu.com/FocalFossa/ReleaseNotes#Python3_by_default
* Add Debian version prefix which is enforced in Ubuntu 20.10 for non-native packages