### PR TITLE
Symbolic icons on Linux

### DIFF
--- a/bleachbit/GUI.py
+++ b/bleachbit/GUI.py
@@ -954,11 +954,11 @@ class GUI(Gtk.ApplicationWindow):
         if os.name == 'nt':
             icon_size = Gtk.IconSize.BUTTON
         else:
-            icon_size = Gtk.IconSize.LARGE_TOOLBAR
+            icon_size = Gtk.IconSize.SMALL_TOOLBAR
 
         # create the preview button
         self.preview_button = Gtk.Button.new_from_icon_name(
-            'edit-find', icon_size)
+            'edit-find-symbolic', icon_size)
         self.preview_button.set_always_show_image(True)
         self.preview_button.connect(
             'clicked', lambda *dummy: self.preview_or_run_operations(False))
@@ -971,7 +971,7 @@ class GUI(Gtk.ApplicationWindow):
 
         # create the delete button
         self.run_button = Gtk.Button.new_from_icon_name(
-            'edit-clear-all', icon_size)
+            'edit-clear-all-symbolic', icon_size)
         self.run_button.set_always_show_image(True)
         # TRANSLATORS: This is the clean button on the main window.
         # It makes permanent changes: usually deleting files, sometimes
@@ -984,7 +984,7 @@ class GUI(Gtk.ApplicationWindow):
 
         # stop cleaning
         self.stop_button = Gtk.Button.new_from_icon_name(
-            'process-stop', icon_size)
+            'process-stop-symbolic', icon_size)
         self.stop_button.set_always_show_image(True)
         self.stop_button.set_label(_('Abort'))
         self.stop_button.set_tooltip_text(


### PR DESCRIPTION
This PR solve problem with Darker Themes (Dark Toolbar & Light Window) & Monochrome icons (Breeze, Papirus & etc)
Before:
![image](https://user-images.githubusercontent.com/8083855/100964313-c9387980-3541-11eb-9c5b-f2759f786bc5.png)
After:
![image](https://user-images.githubusercontent.com/8083855/100964343-db1a1c80-3541-11eb-98ed-421c2b65715c.png)
