### PR TITLE
Import queue module explicitly so that py2exe includes it into library.zip

### DIFF
--- a/bleachbit/Chaff.py
+++ b/bleachbit/Chaff.py
@@ -26,6 +26,7 @@ import os
 import random
 import tempfile
 from datetime import datetime
+import queue as _unused_module_Queue
 
 from bleachbit import _, bleachbit_exe_path
 from bleachbit import options_dir


### PR DESCRIPTION
Fixes #1066 