### PR TITLE
Update thunderbird.xml

### DIFF
--- a/cleaners/thunderbird.xml
+++ b/cleaners/thunderbird.xml
@@ -56,6 +56,12 @@
     <description>Delete the files</description>
     <action command="delete" search="walk.files" path="$$profile$$" regex="\.msf$"/>
   </option>
+  <option id="sessionjson">
+  <!-- delete the session, i.e. open windows and tabs  -->
+    <label>Session restore</label>
+    <description>Loads the initial session after the browser closes or crashes</description>
+    <action command="delete" search="file" path="$$profile$$/session.json"/>
+  </option>
   <option id="passwords">
     <label>Passwords</label>
     <description>A database of usernames and passwords as well as a list of sites that should not store passwords</description>


### PR DESCRIPTION
new option: Delete the session (open windows and tabs, and a little bit of configuration , e.g. display settings layout / message area visible or not - you can look it up yourself by insepcting the session.json file)
Action description: delete the "session.json" (CleanerML code adapted from 'cookies' cleaner option) file in profile directory, in Linux it is "~/.thunderbird/*.default/session.json"
related: https://bugzilla.mozilla.org/show_bug.cgi?id=1690463
(using same label and description as found in firefox.xml saving the effort of translating the text to >60 languages)