### PR TITLE
Fix install Windows fonts for local user.

### DIFF
--- a/windows/bleachbit.nsi
+++ b/windows/bleachbit.nsi
@@ -308,6 +308,9 @@ Section Core (Required)
 
     SetOutPath $INSTDIR
     File /r /x "locale" "..\dist\*.*"
+    
+    CopyFiles $WINDIR\Fonts\segoeui.tt? $INSTDIR\share\fonts
+    CopyFiles $WINDIR\Fonts\tahoma.tt? $INSTDIR\share\fonts
 
     # uninstaller
     WriteUninstaller "$INSTDIR\uninstall.exe"
@@ -414,8 +417,6 @@ Function .onInit
   ExecWait $uninstaller_cmd ; Actually run the uninstaller
 
   new_install:
-  CopyFiles $WINDIR\Fonts\segoeui.tt? $INSTDIR\share\fonts
-  CopyFiles $WINDIR\Fonts\tahoma.tt? $INSTDIR\share\fonts
 
 
 FunctionEnd


### PR DESCRIPTION
Just noticed that when we install for the local user the installer didn't copy the fonts, so I moved the lines responsible for this to a place where the fonts are copied for the local user.