### PR TITLE
Fix 1141: During unit testing use environment variable for setting options dir …

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,7 +74,7 @@ test_script:
   - 'set PATH=c:\windows\system32;c:\windows;c:\windows\system32\wbem;c:\windows\SysWOW64\WindowsPowerShell\v1.0\'
   - '%PYTHON_HOME%/Scripts/pip.exe install mock'
   - 'SET DESTRUCTIVE_TESTS=T'
-  - '%PYTHON_HOME%/Scripts/coverage.exe run --include="bleachbit/*" -m unittest discover -v -p Test*.py'
+  - '%PYTHON_HOME%/Scripts/coverage.exe run --include="bleachbit/*" tests/TestAll.py'
 
 artifacts:
   - path: BleachBit-*-setup.exe

--- a/bleachbit/__init__.py
+++ b/bleachbit/__init__.py
@@ -102,6 +102,12 @@ elif 'nt' == os.name:
     else:
         # installed mode
         options_dir = os.path.expandvars(r"${APPDATA}\BleachBit")
+
+try:
+    options_dir = os.environ['BLEACHBIT_TEST_OPTIONS_DIR']
+except KeyError:
+    pass
+        
 options_file = os.path.join(options_dir, "bleachbit.ini")
 
 # check whether the application is running from the source tree

--- a/tests/TestAll.py
+++ b/tests/TestAll.py
@@ -25,8 +25,14 @@ Run all test suites
 import os
 import unittest
 import sys
+import tempfile
+import shutil
+
 
 if __name__ == '__main__':
+    testdir = tempfile.mkdtemp(prefix='TestAll '+__name__)
+    os.environ['BLEACHBIT_TEST_OPTIONS_DIR'] = testdir
+    
     print("""You should use the unittest discovery, it's much nicer:
     python -m unittest discover -p Test*.py                       # run all tests
     python -m unittest tests.TestCLI                              # run only the CLI tests
@@ -34,4 +40,9 @@ if __name__ == '__main__':
     suite = unittest.defaultTestLoader.discover(
         os.getcwd(), pattern='Test*.py')
     success = unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()
+    
+    del os.environ['BLEACHBIT_TEST_OPTIONS_DIR']
+    if os.path.exists(testdir):
+        shutil.rmtree(testdir)
+    
     sys.exit(success == False)

--- a/tests/TestOptions.py
+++ b/tests/TestOptions.py
@@ -103,6 +103,9 @@ class OptionsTestCase(common.BleachbitTestCase):
 
     def test_init_configuration(self):
         """Test for init_configuration()"""
+        if os.path.exists(bleachbit.options_file):
+            os.remove(bleachbit.options_file)
+        self.assertNotExists(bleachbit.options_file)
         bleachbit.Options.init_configuration()
         self.assertExists(bleachbit.options_file)
 


### PR DESCRIPTION
…and use TestAll.py to run all tests.

 Also I added mocks and they will be used when the environment variable is not set (while running individual tests for example).