### PR TITLE
Create the standard toolbar

### DIFF
--- a/data/app-menu.ui
+++ b/data/app-menu.ui
@@ -46,6 +46,11 @@
         <attribute name="action">app.about</attribute>
         <attribute name="label" translatable="yes">_About BleachBit</attribute>
       </item>
+      <item>
+        <attribute name="label" translatable="yes">_Quit</attribute>
+        <attribute name="action">app.quit</attribute>
+        <attribute name="accel">&lt;Control&gt;q</attribute>
+      </item>
     </section>
   </menu>
 </interface>


### PR DESCRIPTION
This is a solution for #809 for classic desktop environments (Mate and Xfce).

Before:
![before](https://user-images.githubusercontent.com/31816829/122640500-35568580-d100-11eb-9802-c27809ad5c99.png)

After:
![after](https://user-images.githubusercontent.com/31816829/122640503-37204900-d100-11eb-9f39-d023e9a63f15.png)

Only tested with Debian Testing + Mate 1.24/1.26 + gtk3-nocsd.

I also added an item in Application menu, `Quit` with `Control+Q`.
I didn't search why the `Quit` menu isn't translated by GTK.