### PR TITLE
Fix #1084 #1045

### DIFF
--- a/bleachbit.py
+++ b/bleachbit.py
@@ -25,11 +25,11 @@ Launcher
 import os
 import sys
 
-import bleachbit.Unix
 from bleachbit import _
 
 
 if 'posix' == os.name:
+    import bleachbit.Unix
     if os.path.isdir('/usr/share/bleachbit'):
         # This path contains bleachbit/{C,G}LI.py .  This section is
         # unnecessary if installing BleachBit in site-packages.

--- a/bleachbit.py
+++ b/bleachbit.py
@@ -25,11 +25,36 @@ Launcher
 import os
 import sys
 
+import bleachbit.Unix
+
+
 if 'posix' == os.name:
     if os.path.isdir('/usr/share/bleachbit'):
         # This path contains bleachbit/{C,G}LI.py .  This section is
         # unnecessary if installing BleachBit in site-packages.
         sys.path.append('/usr/share/')
+
+        if (
+                bleachbit.Unix.is_linux_display_protocol_wayland() and
+                os.environ['USER'] == 'root' and
+                bleachbit.Unix.root_is_not_allowed_to_X_session()
+            
+        ):
+            print('To run any GUI application on Wayland with root you need to allow the root to connect with '
+                  'the user\'s X session. For example like this:\n'
+                  'xhost si:localuser:root\n'
+                  'After finishing with the application you can remove the connection like this:\n'
+                  'xhost -si:localuser:root\n'
+                  'Please keep in mind that this solution presents a security risk '
+                  'as put by Emmanuele Bassi, a GNOME developer: "there are no real, substantiated, technological '
+                  'reasons why anybody should run a GUI application as root. By running GUI applications as an admin '
+                  'user you are literally running millions of lines of code that have not been audited properly to run '
+                  'under elevated privileges; you are also running code that will touch files inside your $HOME and may '
+                  'change their ownership on the file system; connect, via IPC, to even more running code, etc. You are '
+                  'opening up a massive, gaping security hole. Source:\n'
+                  'https://wiki.archlinux.org/title/Running_GUI_applications_as_root'
+                  )
+            sys.exit(1)
 
 if os.name == 'nt':
     # change error handling to avoid popup with GTK 3

--- a/bleachbit.py
+++ b/bleachbit.py
@@ -26,6 +26,7 @@ import os
 import sys
 
 import bleachbit.Unix
+from bleachbit import _
 
 
 if 'posix' == os.name:
@@ -34,27 +35,27 @@ if 'posix' == os.name:
         # unnecessary if installing BleachBit in site-packages.
         sys.path.append('/usr/share/')
 
-        if (
-                bleachbit.Unix.is_linux_display_protocol_wayland() and
-                os.environ['USER'] == 'root' and
-                bleachbit.Unix.root_is_not_allowed_to_X_session()
-            
-        ):
-            print('To run any GUI application on Wayland with root you need to allow the root to connect with '
-                  'the user\'s X session. For example like this:\n'
-                  'xhost si:localuser:root\n'
-                  'After finishing with the application you can remove the connection like this:\n'
-                  'xhost -si:localuser:root\n'
-                  'Please keep in mind that this solution presents a security risk '
-                  'as put by Emmanuele Bassi, a GNOME developer: "there are no real, substantiated, technological '
-                  'reasons why anybody should run a GUI application as root. By running GUI applications as an admin '
-                  'user you are literally running millions of lines of code that have not been audited properly to run '
-                  'under elevated privileges; you are also running code that will touch files inside your $HOME and may '
-                  'change their ownership on the file system; connect, via IPC, to even more running code, etc. You are '
-                  'opening up a massive, gaping security hole. Source:\n'
-                  'https://wiki.archlinux.org/title/Running_GUI_applications_as_root'
-                  )
-            sys.exit(1)
+    if (
+            bleachbit.Unix.is_linux_display_protocol_wayland() and
+            os.environ['USER'] == 'root' and
+            bleachbit.Unix.root_is_not_allowed_to_X_session()
+
+    ):
+        print(_('To run any GUI application on Wayland with root you need to allow the root to connect with '
+              'the user\'s X session. For example like this:\n'
+              'xhost si:localuser:root\n'
+              'After finishing with the application you can remove the connection like this:\n'
+              'xhost -si:localuser:root\n'
+              'Please keep in mind that this solution presents a security risk '
+              'as put by Emmanuele Bassi, a GNOME developer: "there are no real, substantiated, technological '
+              'reasons why anybody should run a GUI application as root. By running GUI applications as an admin '
+              'user you are literally running millions of lines of code that have not been audited properly to run '
+              'under elevated privileges; you are also running code that will touch files inside your $HOME and may '
+              'change their ownership on the file system; connect, via IPC, to even more running code, etc. You are '
+              'opening up a massive, gaping security hole. Source:\n'
+              'https://wiki.archlinux.org/title/Running_GUI_applications_as_root'
+              ))
+        sys.exit(1)
 
 if os.name == 'nt':
     # change error handling to avoid popup with GTK 3

--- a/bleachbit.py
+++ b/bleachbit.py
@@ -36,10 +36,7 @@ if 'posix' == os.name:
         sys.path.append('/usr/share/')
 
     if (
-            bleachbit.Unix.is_linux_display_protocol_wayland() and
-            os.environ['USER'] == 'root' and
-            bleachbit.Unix.root_is_not_allowed_to_X_session()
-
+        bleachbit.Unix.is_display_protocol_wayland_and_root_not_allowed()
     ):
         print(_('To run any GUI application on Wayland with root you need to allow the root to connect with '
               'the user\'s X session. For example like this:\n'

--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -731,4 +731,19 @@ def dnf_autoremove():
     return freed_bytes
 
 
+def is_linux_display_protocol_wayland():
+    assert(sys.platform.startswith('linux'))
+    result = General.run_external(['loginctl'])
+    session = result[1].split('\n')[1].strip().split(' ')[0]
+    result = General.run_external(['loginctl', 'show-session', session, '-p', 'Type'])
+    return 'wayland' in result[1].lower()
+
+
+def root_is_not_allowed_to_X_session():
+    assert (sys.platform.startswith('linux'))
+    result = General.run_external(['xhost'], clean_env=False)
+    xhost_returned_error = result[0] == 1
+    return xhost_returned_error
+
+
 locales = Locales()

--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -746,4 +746,12 @@ def root_is_not_allowed_to_X_session():
     return xhost_returned_error
 
 
+def is_display_protocol_wayland_and_root_not_allowed():
+    return (
+            bleachbit.Unix.is_linux_display_protocol_wayland() and
+            os.environ['USER'] == 'root' and
+            bleachbit.Unix.root_is_not_allowed_to_X_session()
+    )
+
+
 locales = Locales()


### PR DESCRIPTION
@az0 @abitrolly 
Before starting the PyGtk application I added a check for root with no connection to a display protocol and instead of the error message I show an instruction of how the GUI could be started. This works on my Debian based VMs but I am not sure if the check would be correct under other Linux distributions. Could you take a look at the change and advice? Thanks.