### PR TITLE
Be more clear about Discord Cache Clean

### DIFF
--- a/cleaners/discord.xml
+++ b/cleaners/discord.xml
@@ -30,7 +30,7 @@
   </var>
   <option id="cache">
     <label>Cache</label>
-    <description>Delete the web cache, which reduces time to display revisited pages</description>
+    <description>Delete the web cache, which reduces time to display revisited pages. This also clears favorited GIFs.</description>
     <action command="delete" search="walk.all" path="$$base$$/Cache"/>
     <action command="delete" search="walk.all" path="$$base$$/Code Cache"/>
     <action command="delete" search="walk.all" path="$$base$$/GPUCache"/>


### PR DESCRIPTION
Inform user that clearing Discord Cache might cause unintended clearing of favorited/pinned GIFs.