### PR TITLE
Support square brackets in ExcludeKey path

### DIFF
--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -366,12 +366,10 @@ class Winapp:
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
             search = 'file'
-            type_str = ''
             if dirname.find('*') > -1:
                 search = 'glob'
-                type_str = ' type="d"'
-            action_str = '<option command="delete" search="%s" path="%s"%s/>' % \
-                         (search, xml_escape(dirname), type_str)
+            action_str = '<option command="delete" search="%s" path="%s" type="d"/>' % \
+                         (search, xml_escape(dirname))
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -133,14 +133,10 @@ def special_detect(code):
     return False
 
 
-def escape(matchobj):
-    return '[%s]' % matchobj.group(0)
-
-
 def fnmatch_translate(pattern):
     """Same as the original without the end and escaping square brackets"""
     import fnmatch
-    ret = re.sub('[][]', escape, pattern)
+    ret = re.sub('[][]', lambda m : '[%s]' % m.group(0), pattern)
     ret = fnmatch.translate(ret)
     if ret.endswith('$'):
         return ret[:-1]

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -136,7 +136,7 @@ def special_detect(code):
 def fnmatch_translate(pattern):
     """Same as the original without the end and escaping square brackets"""
     import fnmatch
-    ret = re.sub('[][]', lambda m : '[%s]' % m.group(0), pattern)
+    ret = re.sub('[][]', lambda m: '[%s]' % m.group(0), pattern)
     ret = fnmatch.translate(ret)
     if ret.endswith('$'):
         return ret[:-1]

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -365,8 +365,13 @@ class Winapp:
                      (search, xml_escape(path), regex, excludekeysxml)
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
-            action_str = '<option command="delete" search="file" path="%s"/>' % \
-                         (xml_escape(dirname))
+            search = 'file'
+            type_str = ''
+            if dirname.find('*') > -1:
+                search = 'glob'
+                type_str = ' type="d"'
+            action_str = '<option command="delete" search="%s" path="%s"%s/>' % \
+                         (search, xml_escape(dirname), type_str)
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -136,7 +136,7 @@ def special_detect(code):
 def fnmatch_translate(pattern):
     """Same as the original without the end and escaping square brackets"""
     import fnmatch
-    ret = re.sub('[][]', lambda m: '[%s]' % m.group(0), pattern)
+    ret = re.sub('[][]', lambda m: '[{}]'.format(m.group(0)), pattern)
     ret = fnmatch.translate(ret)
     if ret.endswith('$'):
         return ret[:-1]

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -139,7 +139,7 @@ def escape(matchobj):
 
 def fnmatch_translate(pattern):
     """Same as the original without the end and escaping square brackets"""
-    import fnmatch, re
+    import fnmatch
     ret = re.sub('[][]', escape, pattern)
     ret = fnmatch.translate(ret)
     if ret.endswith('$'):

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -133,10 +133,15 @@ def special_detect(code):
     return False
 
 
+def escape(matchobj):
+    return '[%s]' % matchobj.group(0)
+
+
 def fnmatch_translate(pattern):
-    """Same as the original without the end"""
-    import fnmatch
-    ret = fnmatch.translate(pattern)
+    """Same as the original without the end and escaping square brackets"""
+    import fnmatch, re
+    ret = re.sub('[][]', escape, pattern)
+    ret = fnmatch.translate(ret)
     if ret.endswith('$'):
         return ret[:-1]
     if ret.endswith(r'\Z(?ms)'):
@@ -365,11 +370,8 @@ class Winapp:
                      (search, xml_escape(path), regex, excludekeysxml)
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
-            search = 'file'
-            if dirname.find('*') > -1:
-                search = 'glob'
-            action_str = '<option command="delete" search="%s" path="%s" type="d"/>' % \
-                         (search, xml_escape(dirname))
+            action_str = '<option command="delete" search="file" path="%s"/>' % \
+                         (xml_escape(dirname))
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -430,6 +430,15 @@ class WinappTestCase(common.BleachbitTestCase):
             # cleanup
             shutil.rmtree(dirname, True)
             
+    @common.skipUnlessWindows
+    def test_excludekey_square_brackets(self):
+        """Test for ExcludeKey with square brackets"""
+
+        # reuse this path to store a winapp2.ini file in
+        (ini_h, self.ini_fn) = tempfile.mkstemp(
+            suffix='.ini', prefix='winapp2')
+        os.close(ini_h)           
+            
         # indices for tests when the ExcludeKey includes square brackets
         # position 0: FileKey statement
         # position 1: whether the file `sub\foo.log` should exist after operation is complete

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -429,6 +429,64 @@ class WinappTestCase(common.BleachbitTestCase):
 
             # cleanup
             shutil.rmtree(dirname, True)
+            
+        # indices for ExcludeKey tests when filepath includes square brackets
+        # position 0: FileKey statement
+        # position 1: whether the file `sub\foo.log` should exist after operation is complete
+        # position 2: whether the file `sub\foo[1].log` should exist after operation is complete
+        # position 3: whether the file `sub[1]\foo.log` should exist after operation is complete
+        # position 4: whether the file `sub[1]\foo[1].log` should exist after operation is complete
+
+        tests = (
+            # delete files directly without exclusions
+            ('FileKey1=%(d)s\sub|foo.log', False, True, True, True),
+            ('FileKey1=%(d)s\sub|foo[1].log', True, False, True, True),
+            ('FileKey1=%(d)s\sub[1]|foo.log', True, True, False, True),
+            ('FileKey1=%(d)s\sub[1]|foo[1].log', True, True, True, False),
+            ('FileKey1=%(d)s\sub|foo*.log', False, False, True, True),
+            ('FileKey1=%(d)s\sub[1]|foo*.log', True, True, False, False),
+            ('FileKey1=%(d)s\sub*|foo*.log', False, False, False, False),
+            # delete files recursively without exclusions
+            ('FileKey1=%(d)s|*.log|RECURSE', False, False, False, False),
+            ('FileKey1=%(d)s|*.*|RECURSE', False, False, False, False),
+            # exclude specific file
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub|foo.log', True, False, False, False),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub|foo[1].log', False, True, False, False),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub[1]|foo.log', False, False, True, False),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub[1]|foo[1].log', False, False, False, True),
+            # exclude everything in folder
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub|*.*', True, True, False, False),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub[1]|*.*', False, False, True, True),
+            # exclude sub-folder
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub', True, True, False, False),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub[1]', False, False, True, True),
+        )
+
+        for test in tests:
+            msg = '\nTest:\n%s' % test[0]
+            # setup
+            fn1 = os.path.join(dirname, 'sub', 'foo.log')
+            fn2 = os.path.join(dirname, 'sub', 'foo[1].log')
+            fn3 = os.path.join(dirname, 'sub[1]', 'foo.log')
+            fn4 = os.path.join(dirname, 'sub[1]', 'foo[1].log')
+            common.touch_file(fn1)
+            common.touch_file(fn2)
+            common.touch_file(fn3)
+            common.touch_file(fn4)
+            self.assertExists(r'%s\sub\foo.log' % dirname, msg)
+            self.assertExists(r'%s\sub\foo[1].log' % dirname, msg)
+            self.assertExists(r'%s\sub[1]\foo.log' % dirname, msg)
+            self.assertExists(r'%s\sub[1]\foo[1].log' % dirname, msg)
+            # delete files
+            cleaner = self.ini2cleaner(test[0] % {'d': dirname})
+            self.run_all(cleaner, True)
+            # tests
+            self.assertCondExists(test[1], r'%s\sub\foo.log' % dirname, msg)
+            self.assertCondExists(test[2], r'%s\sub\foo[1].log' % dirname, msg)
+            self.assertCondExists(test[3], r'%s\sub[1]\foo.log' % dirname, msg)
+            self.assertCondExists(test[4], r'%s\sub[1]\foo[1].log' % dirname, msg)
+            # cleanup
+            shutil.rmtree(dirname, True)
 
     def test_section2option(self):
         """Test for section2option()"""

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -464,6 +464,7 @@ class WinappTestCase(common.BleachbitTestCase):
         for test in tests:
             msg = '\nTest:\n%s' % test[0]
             # setup
+            dirname = tempfile.mkdtemp(prefix='bleachbit-test-winapp')
             fn1 = os.path.join(dirname, 'sub', 'foo.log')
             fn2 = os.path.join(dirname, 'sub', 'foo[1].log')
             common.touch_file(fn1)

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -430,7 +430,7 @@ class WinappTestCase(common.BleachbitTestCase):
             # cleanup
             shutil.rmtree(dirname, True)
             
-        # indices for ExcludeKey tests when filename (*not* the path) includes square brackets
+        # indices for tests when the ExcludeKey includes square brackets
         # position 0: FileKey statement
         # position 1: whether the file `sub\foo.log` should exist after operation is complete
         # position 2: whether the file `sub\foo[1].log` should exist after operation is complete

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -434,31 +434,22 @@ class WinappTestCase(common.BleachbitTestCase):
         # position 0: FileKey statement
         # position 1: whether the file `sub\foo.log` should exist after operation is complete
         # position 2: whether the file `sub\foo[1].log` should exist after operation is complete
-        # position 3: whether the file `sub[1]\foo.log` should exist after operation is complete
-        # position 4: whether the file `sub[1]\foo[1].log` should exist after operation is complete
 
         tests = (
             # delete files directly without exclusions
-            ('FileKey1=%(d)s\sub|foo.log', False, True, True, True),
-            ('FileKey1=%(d)s\sub|foo[1].log', True, False, True, True),
-            ('FileKey1=%(d)s\sub[1]|foo.log', True, True, False, True),
-            ('FileKey1=%(d)s\sub[1]|foo[1].log', True, True, True, False),
-            ('FileKey1=%(d)s\sub|foo*.log', False, False, True, True),
-            ('FileKey1=%(d)s\sub*|foo*.log', False, False, False, False),
+            ('FileKey1=%(d)s\sub|foo.log', False, True),
+            ('FileKey1=%(d)s\sub|foo[1].log', True, False),
+            ('FileKey1=%(d)s\sub|foo*.log', False, False),
             # delete files recursively without exclusions
-            ('FileKey1=%(d)s|*.log|RECURSE', False, False, False, False),
-            ('FileKey1=%(d)s|*.*|RECURSE', False, False, False, False),
+            ('FileKey1=%(d)s|*.log|RECURSE', False, False),
+            ('FileKey1=%(d)s|*.*|RECURSE', False, False),
             # exclude specific file
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub|foo.log', True, False, False, False),
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub|foo[1].log', False, True, False, False),
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub[1]|foo.log', False, False, True, False),
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub[1]|foo[1].log', False, False, False, True),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub|foo.log', True, False),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub|foo[1].log', False, True),
             # exclude everything in folder
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub|*.*', True, True, False, False),
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub[1]|*.*', False, False, True, True),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub|*.*', True, True),
             # exclude sub-folder
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub', True, True, False, False),
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub[1]', False, False, True, True),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub', True, True),
         )
 
         for test in tests:
@@ -466,24 +457,16 @@ class WinappTestCase(common.BleachbitTestCase):
             # setup
             fn1 = os.path.join(dirname, 'sub', 'foo.log')
             fn2 = os.path.join(dirname, 'sub', 'foo[1].log')
-            fn3 = os.path.join(dirname, 'sub[1]', 'foo.log')
-            fn4 = os.path.join(dirname, 'sub[1]', 'foo[1].log')
             common.touch_file(fn1)
             common.touch_file(fn2)
-            common.touch_file(fn3)
-            common.touch_file(fn4)
             self.assertExists(r'%s\sub\foo.log' % dirname, msg)
             self.assertExists(r'%s\sub\foo[1].log' % dirname, msg)
-            self.assertExists(r'%s\sub[1]\foo.log' % dirname, msg)
-            self.assertExists(r'%s\sub[1]\foo[1].log' % dirname, msg)
             # delete files
             cleaner = self.ini2cleaner(test[0] % {'d': dirname})
             self.run_all(cleaner, True)
             # tests
             self.assertCondExists(test[1], r'%s\sub\foo.log' % dirname, msg)
             self.assertCondExists(test[2], r'%s\sub\foo[1].log' % dirname, msg)
-            self.assertCondExists(test[3], r'%s\sub[1]\foo.log' % dirname, msg)
-            self.assertCondExists(test[4], r'%s\sub[1]\foo[1].log' % dirname, msg)
             # cleanup
             shutil.rmtree(dirname, True)
 

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -430,36 +430,26 @@ class WinappTestCase(common.BleachbitTestCase):
             # cleanup
             shutil.rmtree(dirname, True)
             
-        # indices for ExcludeKey tests when filepath includes square brackets
+        # indices for ExcludeKey tests when filename (*not* the path) includes square brackets
         # position 0: FileKey statement
         # position 1: whether the file `sub\foo.log` should exist after operation is complete
         # position 2: whether the file `sub\foo[1].log` should exist after operation is complete
-        # position 3: whether the file `sub[1]\foo.log` should exist after operation is complete
-        # position 4: whether the file `sub[1]\foo[1].log` should exist after operation is complete
 
         tests = (
             # delete files directly without exclusions
-            ('FileKey1=%(d)s\sub|foo.log', False, True, True, True),
-            ('FileKey1=%(d)s\sub|foo[1].log', True, False, True, True),
-            ('FileKey1=%(d)s\sub[1]|foo.log', True, True, False, True),
-            ('FileKey1=%(d)s\sub[1]|foo[1].log', True, True, True, False),
-            ('FileKey1=%(d)s\sub|foo*.log', False, False, True, True),
-            ('FileKey1=%(d)s\sub[1]|foo*.log', True, True, False, False),
-            ('FileKey1=%(d)s\sub*|foo*.log', False, False, False, False),
+            ('FileKey1=%(d)s\sub|foo.log', False, True),
+            ('FileKey1=%(d)s\sub|foo[1].log', True, False),
+            ('FileKey1=%(d)s\sub|foo*.log', False, False),
             # delete files recursively without exclusions
-            ('FileKey1=%(d)s|*.log|RECURSE', False, False, False, False),
-            ('FileKey1=%(d)s|*.*|RECURSE', False, False, False, False),
+            ('FileKey1=%(d)s|*.log|RECURSE', False, False),
+            ('FileKey1=%(d)s|*.*|RECURSE', False, False),
             # exclude specific file
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub|foo.log', True, False, False, False),
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub|foo[1].log', False, True, False, False),
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub[1]|foo.log', False, False, True, False),
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub[1]|foo[1].log', False, False, False, True),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub|foo.log', True, False),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=FILE|%(d)s\sub|foo[1].log', False, True),
             # exclude everything in folder
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub|*.*', True, True, False, False),
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub[1]|*.*', False, False, True, True),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub|*.*', True, True),
             # exclude sub-folder
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub', True, True, False, False),
-            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub[1]', False, False, True, True),
+            ('FileKey1=%(d)s|*.log|RECURSE\nExcludeKey1=PATH|%(d)s\sub', True, True),
         )
 
         for test in tests:
@@ -467,24 +457,16 @@ class WinappTestCase(common.BleachbitTestCase):
             # setup
             fn1 = os.path.join(dirname, 'sub', 'foo.log')
             fn2 = os.path.join(dirname, 'sub', 'foo[1].log')
-            fn3 = os.path.join(dirname, 'sub[1]', 'foo.log')
-            fn4 = os.path.join(dirname, 'sub[1]', 'foo[1].log')
             common.touch_file(fn1)
             common.touch_file(fn2)
-            common.touch_file(fn3)
-            common.touch_file(fn4)
             self.assertExists(r'%s\sub\foo.log' % dirname, msg)
             self.assertExists(r'%s\sub\foo[1].log' % dirname, msg)
-            self.assertExists(r'%s\sub[1]\foo.log' % dirname, msg)
-            self.assertExists(r'%s\sub[1]\foo[1].log' % dirname, msg)
             # delete files
             cleaner = self.ini2cleaner(test[0] % {'d': dirname})
             self.run_all(cleaner, True)
             # tests
             self.assertCondExists(test[1], r'%s\sub\foo.log' % dirname, msg)
             self.assertCondExists(test[2], r'%s\sub\foo[1].log' % dirname, msg)
-            self.assertCondExists(test[3], r'%s\sub[1]\foo.log' % dirname, msg)
-            self.assertCondExists(test[4], r'%s\sub[1]\foo[1].log' % dirname, msg)
             # cleanup
             shutil.rmtree(dirname, True)
 


### PR DESCRIPTION
Not sure it's worth it. Only few paths in winapp2.ini include square brackets but they do exist.

Example: `ExcludeKey1=FILE|%LocalAppData%\Packages\Microsoft.MicrosoftOfficeHub_*\AC\Microsoft\Internet Explorer\DOMStore\*\|www.office[1].xml`

Note for testing: This needs #1249 otherwise exclusions won't work at all anyhow.