### PR TITLE
Actually delete IE webcache (e.g. dom cookies)

### DIFF
--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -366,12 +366,10 @@ class Winapp:
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
             search = 'file'
-            type_str = ''
             if dirname.find('*') > -1:
                 search = 'glob'
-                type_str = ' type="d"'
-            action_str = '<option command="delete" search="%s" path="%s"%s/>' % \
-                         (search, xml_escape(dirname), type_str)
+            action_str = '<option command="delete" search="%s" path="%s" type="d"/>' % \
+                         (search, xml_escape(dirname))
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -365,11 +365,8 @@ class Winapp:
                      (search, xml_escape(path), regex, excludekeysxml)
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
-            search = 'file'
-            if dirname.find('*') > -1:
-                search = 'glob'
-            action_str = '<option command="delete" search="%s" path="%s" type="d"/>' % \
-                         (search, xml_escape(dirname))
+            action_str = '<option command="delete" search="file" path="%s"/>' % \
+                         (xml_escape(dirname))
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -365,8 +365,13 @@ class Winapp:
                      (search, xml_escape(path), regex, excludekeysxml)
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
-            action_str = '<option command="delete" search="file" path="%s"/>' % \
-                         (xml_escape(dirname))
+            search = 'file'
+            type_str = ''
+            if dirname.find('*') > -1:
+                search = 'glob'
+                type_str = ' type="d"'
+            action_str = '<option command="delete" search="%s" path="%s"%s/>' % \
+                         (search, xml_escape(dirname), type_str)
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/cleaners/internet_explorer.xml
+++ b/cleaners/internet_explorer.xml
@@ -91,8 +91,10 @@
     <action command="delete" search="walk.all" path="%AppData%\Microsoft\Windows\IECompatUACache\"/>
     <action command="delete" search="walk.all" path="%AppData%\Microsoft\Windows\IECompat*Cache\"/>
     <action command="delete" search="walk.all" path="$$IELocalAppData$$\INetCache\"/>
+    <action command="process" cmd="schtasks /end /tn \Microsoft\Windows\Wininet\CacheTask"/>
     <action command="delete" search="walk.all" path="$$IELocalAppData$$\WebCache\"/>
     <action command="delete" search="walk.top" path="$$IELocalAppData$$\WebCache.old\"/>
+    <action command="process" cmd="schtasks /run /tn \Microsoft\Windows\Wininet\CacheTask"/>
     <!-- Empty folder on the demo machine: (Tobias) -->
     <action command="delete" search="walk.all" path="%LocalAppDataLow%\Microsoft\Internet Explorer\iconcache\"/>
     <!-- Extras - making WinApp2.ini obsolete: -->

--- a/cleaners/internet_explorer.xml
+++ b/cleaners/internet_explorer.xml
@@ -42,6 +42,11 @@
     <!-- Used e.g. in Windows XP (and maybe before on NT) with e.g. Internet Explorer 8 - Polish-Support: -->
     <value>%UserProfile%\Ustawienia lokalne</value>
   </var>
+  <!-- system directory 32-bit and 64-bit; when BleachBit gets a native 64-bit edition replace SysNative with SysWOW64 -->
+  <var name="SysDir">
+    <value>%WinDir%\System32</value>
+    <value>%WinDir%\SysNative</value>
+  </var>
   <option id="cookies">
     <label>Cookies</label>
     <description>Delete cookies, which contain information such as web site preferences, authentication, and tracking identification</description>
@@ -108,7 +113,7 @@
     <action command="delete" search="walk.all" path="%LocalAppData%\Packages\windows_ie_ac_*\AC\Temp\"/>
     <action command="delete" search="walk.all" path="%LocalAppData%\Packages\windows_ie_ac_*\LocalState\Cache\"/>
     <action command="delete" search="walk.all" path="%LocalAppData%\Packages\windows_ie_ac_*\TempState\"/>
-    <action command="delete" search="walk.all" path="%WinDir%\System32\config\Systemprofile\AppData\Local\Microsoft\Windows\INetCache\"/>
+    <action command="delete" search="walk.all" path="$$SysDir$$\config\Systemprofile\AppData\Local\Microsoft\Windows\INetCache\"/>
     <action command="winreg" path="HKCR\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\windows_ie_ac_001\Internet Explorer\DOMStorage"/>
     <action command="winreg" path="HKCU\Software\Microsoft\Internet Explorer\LowRegistry\DOMStorage"/>
     <!-- Deletes Feeds Cache: -->


### PR DESCRIPTION
Some files in the IE webcache (including the most important one for history, cookies, etc.) were never actually deleted because they are always in use by Wininet\CacheTask. This commit fixes that.