### PR TITLE
Winapp compliance

### DIFF
--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -366,12 +366,10 @@ class Winapp:
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
             search = 'file'
-            type_str = ''
             if dirname.find('*') > -1:
                 search = 'glob'
-                type_str = ' type="d"'
-            action_str = '<option command="delete" search="%s" path="%s"%s/>' % \
-                         (search, xml_escape(dirname), type_str)
+            action_str = '<option command="delete" search="%s" path="%s" type="d"/>' % \
+                         (search, xml_escape(dirname))
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -365,8 +365,11 @@ class Winapp:
                      (search, xml_escape(path), regex, excludekeysxml)
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
-            action_str = '<option command="delete" search="file" path="%s"/>' % \
-                         (xml_escape(dirname))
+            search = 'file'
+            if dirname.find('*') > -1:
+                search = 'glob'
+            action_str = '<option command="delete" search="%s" path="%s" type="d"/>' % \
+                         (search, xml_escape(dirname))
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -349,7 +349,7 @@ class Winapp:
                 regex = ' regex="^%s$" ' % (fnmatch.translate(filename))
         else:
             search = 'glob'
-            files_only = 'type="f"'
+            files_only = ' type="f" '
             pattern = filename
             if pattern == '*.*':
                 pattern = '*'
@@ -370,7 +370,7 @@ class Winapp:
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
             search = 'file'
-            if dirname.find('*') > -1:
+            if dirname.find('*') != -1:
                 search = 'glob'
             action_str = '<option command="delete" search="%s" path="%s" type="d"/>' % \
                          (search, xml_escape(dirname))

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -365,11 +365,8 @@ class Winapp:
                      (search, xml_escape(path), regex, excludekeysxml)
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
-            search = 'file'
-            if dirname.find('*') > -1:
-                search = 'glob'
-            action_str = '<option command="delete" search="%s" path="%s" type="d"/>' % \
-                         (search, xml_escape(dirname))
+            action_str = '<option command="delete" search="file" path="%s"/>' % \
+                         (xml_escape(dirname))
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -351,7 +351,7 @@ class Winapp:
             search = 'glob'
             files_only = 'type="f"'
             pattern = filename
-            if pattern == '*.*'
+            if pattern == '*.*':
                 pattern = '*'
             path = os.path.join(dirname, pattern)
             if path.find('*') == -1:

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -365,8 +365,13 @@ class Winapp:
                      (search, xml_escape(path), regex, excludekeysxml)
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
-            action_str = '<option command="delete" search="file" path="%s"/>' % \
-                         (xml_escape(dirname))
+            search = 'file'
+            type_str = ''
+            if dirname.find('*') > -1:
+                search = 'glob'
+                type_str = ' type="d"'
+            action_str = '<option command="delete" search="%s" path="%s"%s/>' % \
+                         (search, xml_escape(dirname), type_str)
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -337,19 +337,23 @@ class Winapp:
 
     def __make_file_provider(self, dirname, filename, recurse, removeself, excludekeys):
         """Change parsed FileKey to action provider"""
+        files_only = ''
         regex = ''
         if recurse:
             search = 'walk.files'
             path = dirname
             if filename == '*.*':
-                if removeself:
-                    search = 'walk.all'
+                search = 'walk.all'
             else:
                 import fnmatch
                 regex = ' regex="^%s$" ' % (fnmatch.translate(filename))
         else:
             search = 'glob'
-            path = os.path.join(dirname, filename)
+            files_only = 'type="f"'
+            pattern = filename
+            if pattern == '*.*'
+                pattern = '*'
+            path = os.path.join(dirname, pattern)
             if path.find('*') == -1:
                 search = 'file'
         excludekeysxml = ''
@@ -361,8 +365,8 @@ class Winapp:
                 # just one
                 exclude_str = excludekeys[0]
             excludekeysxml = 'nwholeregex="%s"' % xml_escape(exclude_str)
-        action_str = '<option command="delete" search="%s" path="%s" %s %s/>' % \
-                     (search, xml_escape(path), regex, excludekeysxml)
+        action_str = '<option command="delete" search="%s" path="%s" %s %s %s/>' % \
+                     (search, xml_escape(path), files_only, regex, excludekeysxml)
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
             search = 'file'

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -435,6 +435,60 @@ class WinappTestCase(common.BleachbitTestCase):
 
             # cleanup
             shutil.rmtree(dirname, True)
+            
+    @common.skipUnlessWindows
+    def test_removeself(self):
+        """Test for the removeself option"""
+
+        # indexes for test
+        # position 0: FileKey statement
+        # position 1: whether the file `dir_c\subdir\foo.log` should exist after operation is complete
+        tests = (
+            # Refer to directory directly (i.e., without a glob).
+            (r'FileKey1=%s\dir_c|*.*|REMOVESELF' % self.tempdir, False),
+            # Refer to file that exists. This is invalid, so nothing happens.
+            (r'FileKey1=%s\dir_c\submarine_sandwich.log|*.*|REMOVESELF' %
+             self.tempdir, True),
+            (r'FileKey1=%s\dir_c\submarine*|*.*|REMOVESELF' % self.tempdir, True),
+            # Refer to path that does not exist, so nothing happens.
+            (r'FileKey1=%s\dir_c\doesnotexist.log|*.*|REMOVESELF' %
+             self.tempdir, True),
+            # Refer by glob to both a file and directory (which both start with `sub`).
+            # This should affect only the directory.
+            (r'FileKey1=%s\dir_c\sub*|*.*|REMOVESELF' % self.tempdir, False),
+            # glob in middle of directory path with whole directory entry
+            (r'FileKey1=%s\*c\subdir|*.*|REMOVESELF' % self.tempdir, False),
+            (r'FileKey1=%s\*doesnotexist\subdir|*.*|REMOVESELF' % self.tempdir, True),
+            # glob at end of path
+            (r'FileKey1=%s\dir_c\sub*|*.*|REMOVESELF' % self.tempdir, False),
+            (r'FileKey1=%s\dir_c\doesnotexist*|*.*|REMOVESELF' % self.tempdir, True)
+        )
+
+        (ini_h, self.ini_fn) = tempfile.mkstemp(
+            suffix='.ini', prefix='winapp2')
+        os.close(ini_h)
+
+        for filekey, c_log_expected in tests:
+            for letter in ('a', 'b', 'c'):
+                # Make three directories, each with a `foo.log` file.
+                fn = os.path.join(self.tempdir, 'dir_' +
+                                  letter, 'subdir', 'foo.log')
+                common.touch_file(fn)
+
+            # In dir_a, place a file one level up from `foo.log`.
+            # Notice the glob `dir_a\sub*` will match both a directory and file.
+            fn2 = os.path.join(self.tempdir, 'dir_a', 'submarine_sandwich.log')
+            common.touch_file(fn2)
+
+            cleaner = self.ini2cleaner(filekey)
+            self.assertExists(fn, filekey)
+            self.assertExists(fn2, filekey)
+            self.run_all(cleaner, True)
+            if c_log_expected:
+                self.assertExists(fn, filekey)
+            else:
+                self.assertNotExists(fn, filekey)
+            self.assertExists(fn2, filekey)
 
     def test_section2option(self):
         """Test for section2option()"""

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -436,60 +436,6 @@ class WinappTestCase(common.BleachbitTestCase):
             # cleanup
             shutil.rmtree(dirname, True)
 
-    @common.skipUnlessWindows
-    def test_removeself(self):
-        """Test for the removeself option"""
-
-        # indexes for test
-        # position 0: FileKey statement
-        # position 1: whether the file `dir_c\subdir\foo.log` should exist after operation is complete
-        tests = (
-            # Refer to directory directly (i.e., without a glob).
-            (r'FileKey1=%s\dir_c|*.*|REMOVESELF' % self.tempdir, False),
-            # Refer to file that exists. This is invalid, so nothing happens.
-            (r'FileKey1=%s\dir_c\submarine_sandwich.log|*.*|REMOVESELF' %
-             self.tempdir, True),
-            (r'FileKey1=%s\dir_c\submarine*|*.*|REMOVESELF' % self.tempdir, True),
-            # Refer to path that does not exist, so nothing happens.
-            (r'FileKey1=%s\dir_c\doesnotexist.log|*.*|REMOVESELF' %
-             self.tempdir, True),
-            # Refer by glob to both a file and directory (which both start with `sub`).
-            # This should affect only the directory.
-            (r'FileKey1=%s\dir_c\sub*|*.*|REMOVESELF' % self.tempdir, False),
-            # glob in middle of directory path with whole directory entry
-            (r'FileKey1=%s\*c\subdir|*.*|REMOVESELF' % self.tempdir, False),
-            (r'FileKey1=%s\*doesnotexist\subdir|*.*|REMOVESELF' % self.tempdir, True),
-            # glob at end of path
-            (r'FileKey1=%s\dir_c\sub*|*.*|REMOVESELF' % self.tempdir, False),
-            (r'FileKey1=%s\dir_c\doesnotexist*|*.*|REMOVESELF' % self.tempdir, True)
-        )
-
-        (ini_h, self.ini_fn) = tempfile.mkstemp(
-            suffix='.ini', prefix='winapp2')
-        os.close(ini_h)
-
-        for filekey, c_log_expected in tests:
-            for letter in ('a', 'b', 'c'):
-                # Make three directories, each with a `foo.log` file.
-                fn = os.path.join(self.tempdir, 'dir_' +
-                                  letter, 'subdir', 'foo.log')
-                common.touch_file(fn)
-
-            # In dir_a, place a file one level up from `foo.log`.
-            # Notice the glob `dir_a\sub*` will match both a directory and file.
-            fn2 = os.path.join(self.tempdir, 'dir_a', 'submarine_sandwich.log')
-            common.touch_file(fn2)
-
-            cleaner = self.ini2cleaner(filekey)
-            self.assertExists(fn, filekey)
-            self.assertExists(fn2, filekey)
-            self.run_all(cleaner, True)
-            if c_log_expected:
-                self.assertExists(fn, filekey)
-            else:
-                self.assertNotExists(fn, filekey)
-            self.assertExists(fn2, filekey)
-
     def test_section2option(self):
         """Test for section2option()"""
         tests = (('  FOO2  ', 'foo2'),

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -435,7 +435,7 @@ class WinappTestCase(common.BleachbitTestCase):
 
             # cleanup
             shutil.rmtree(dirname, True)
-            
+
     @common.skipUnlessWindows
     def test_removeself(self):
         """Test for the removeself option"""

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -348,8 +348,8 @@ class WinappTestCase(common.BleachbitTestCase):
             ('FileKey1=%(d)s|deleteme.*|RECURSE', False, False, False),
             # don't delete files containing the described file name
             ('FileKey1=%(d)s|eteme.*|RECURSE', True, True, True),
-            # delete a pattern sub folder not included
-            ('FileKey1=%(d)s|*eteme.*|RECURSE', False, False, True),
+            # delete a pattern sub folder included
+            ('FileKey1=%(d)s|*eteme.*|RECURSE', False, False, False),
             # delete a pattern sub folder not included
             ('FileKey1=%(d)s|*eteme.*', False, False, True),
             # exclude log delimited by pipe

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -348,8 +348,8 @@ class WinappTestCase(common.BleachbitTestCase):
             ('FileKey1=%(d)s|deleteme.*|RECURSE', False, False, False),
             # don't delete files containing the described file name
             ('FileKey1=%(d)s|eteme.*|RECURSE', True, True, True),
-            # delete a pattern sub folder included
-            ('FileKey1=%(d)s|*eteme.*|RECURSE', False, False, False),
+            # delete a pattern sub folder not included
+            ('FileKey1=%(d)s|*eteme.*|RECURSE', False, False, True),
             # delete a pattern sub folder not included
             ('FileKey1=%(d)s|*eteme.*', False, False, True),
             # exclude log delimited by pipe


### PR DESCRIPTION
Tried to make winapp behaviour more closely resemble the reference cleaner tool:

`*.*` means 'all files', with or without a '.'. So 'file_without_extension' gets deleted but 'folder1.0' doesn't match.

Only with RECURSE or REMOVESELF _empty_ folders are deleted afterwards.

