### PR TITLE
Support getting the windows version on Windows 8 or later

### DIFF
--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -366,12 +366,10 @@ class Winapp:
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
             search = 'file'
-            type_str = ''
             if dirname.find('*') > -1:
                 search = 'glob'
-                type_str = ' type="d"'
-            action_str = '<option command="delete" search="%s" path="%s"%s/>' % \
-                         (search, xml_escape(dirname), type_str)
+            action_str = '<option command="delete" search="%s" path="%s" type="d"/>' % \
+                         (search, xml_escape(dirname))
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -365,8 +365,11 @@ class Winapp:
                      (search, xml_escape(path), regex, excludekeysxml)
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
-            action_str = '<option command="delete" search="file" path="%s"/>' % \
-                         (xml_escape(dirname))
+            search = 'file'
+            if dirname.find('*') > -1:
+                search = 'glob'
+            action_str = '<option command="delete" search="%s" path="%s" type="d"/>' % \
+                         (search, xml_escape(dirname))
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -365,11 +365,8 @@ class Winapp:
                      (search, xml_escape(path), regex, excludekeysxml)
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
-            search = 'file'
-            if dirname.find('*') > -1:
-                search = 'glob'
-            action_str = '<option command="delete" search="%s" path="%s" type="d"/>' % \
-                         (search, xml_escape(dirname))
+            action_str = '<option command="delete" search="file" path="%s"/>' % \
+                         (xml_escape(dirname))
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/bleachbit/Winapp.py
+++ b/bleachbit/Winapp.py
@@ -365,8 +365,13 @@ class Winapp:
                      (search, xml_escape(path), regex, excludekeysxml)
         yield Delete(parseString(action_str).childNodes[0])
         if removeself:
-            action_str = '<option command="delete" search="file" path="%s"/>' % \
-                         (xml_escape(dirname))
+            search = 'file'
+            type_str = ''
+            if dirname.find('*') > -1:
+                search = 'glob'
+                type_str = ' type="d"'
+            action_str = '<option command="delete" search="%s" path="%s"%s/>' % \
+                         (search, xml_escape(dirname), type_str)
             yield Delete(parseString(action_str).childNodes[0])
 
     def handle_filekey(self, lid, ini_section, ini_option, excludekeys):

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -461,6 +461,7 @@ def get_recycle_bin():
 
 def get_windows_version():
     """Get the Windows major and minor version in a decimal like 10.0"""
+    import platform
     v = platform.win32_ver()[1].split('.')
     vstr = '%d.%d' % (v[0], v[1])
     return Decimal(vstr)

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -462,9 +462,7 @@ def get_recycle_bin():
 def get_windows_version():
     """Get the Windows major and minor version in a decimal like 10.0"""
     import platform
-    v = platform.win32_ver()[1].split('.')
-    vstr = '{}.{}'.format(v[0], v[1])
-    return Decimal(vstr)
+    return Decimal('.'.join(platform.win32_ver()[1].split('.')[0:2]))
 
 
 def is_junction(path):

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -461,7 +461,7 @@ def get_recycle_bin():
 
 def get_windows_version():
     """Get the Windows major and minor version in a decimal like 10.0"""
-    v = sys.getwindowsversion().platform_version
+    v = platform.win32_ver()[1].split('.')
     vstr = '%d.%d' % (v[0], v[1])
     return Decimal(vstr)
 

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -462,7 +462,7 @@ def get_recycle_bin():
 def get_windows_version():
     """Get the Windows major and minor version in a decimal like 10.0"""
     import platform
-    return Decimal('.'.join(platform.version().split('.')[0:2]))
+    return Decimal('.'.join(platform.win32_ver()[1].split('.')[0:2]))
 
 
 def is_junction(path):

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -462,7 +462,7 @@ def get_recycle_bin():
 def get_windows_version():
     """Get the Windows major and minor version in a decimal like 10.0"""
     import platform
-    return Decimal('.'.join(platform.win32_ver()[1].split('.')[0:2]))
+    return Decimal('.'.join(platform.version().split('.')[0:2]))
 
 
 def is_junction(path):

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -461,7 +461,7 @@ def get_recycle_bin():
 
 def get_windows_version():
     """Get the Windows major and minor version in a decimal like 10.0"""
-    v = win32api.GetVersionEx(0)
+    v = sys.getwindowsversion().platform_version
     vstr = '%d.%d' % (v[0], v[1])
     return Decimal(vstr)
 

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -463,7 +463,7 @@ def get_windows_version():
     """Get the Windows major and minor version in a decimal like 10.0"""
     import platform
     v = platform.win32_ver()[1].split('.')
-    vstr = '%d.%d' % (v[0], v[1])
+    vstr = '{}.{}'.format(v[0], v[1])
     return Decimal(vstr)
 
 

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -477,7 +477,6 @@ def is_junction(path):
     return bool(attr & FILE_ATTRIBUTE_REPARSE_POINT)
 
 
-
 def is_process_running(name):
     """Return boolean whether process (like firefox.exe) is running
 
@@ -600,7 +599,7 @@ def symlink_or_copy(src, dst):
     try:
         os.symlink(src, dst)
         logger.debug('linked %s to %s', src, dst)
-    except PermissionError as e:
+    except (PermissionError, OSError) as e:
         shutil.copy(src, dst)
         logger.debug('copied %s to %s', src, dst)
 

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -605,9 +605,13 @@ def symlink_or_copy(src, dst):
 
 
 def copy_fonts_in_portable_app(auto_exit):
-    # Fix #1040: copy only two fonts in order to escape huge default fontconfig caching.
-    # We do this here only for portable app as for the installed app we do it through the installer.
+    """
+    Fix #1040: copy only two fonts in order to escape huge default fontconfig caching.
+    We do this here only for portable app as for the installed app we do it through the installer.
 
+    This lists fonts that Microsoft provides:
+    https://docs.microsoft.com/en-us/typography/fonts/windows_10_font_list
+    """
     if (
         hasattr(sys, 'frozen') and
         bleachbit.portable_mode and
@@ -624,8 +628,9 @@ def copy_fonts_in_portable_app(auto_exit):
             lang_id = '??'
         logger.debug('detected lang_id=%s', lang_id)
         extra_fonts = {}
-        extra_fonts['kr'] = ['malgun.ttf', 'malgunbd.ttf', 'malgunsl.ttf']
-        extra_fonts['ja'] = ['meiryo.ttc', 'meiryob.ttc']
+        extra_fonts['ko'] = ['malgun.ttf', 'malgunbd.ttf', 'malgunsl.ttf']
+        extra_fonts['hi'] = ['mangal.ttf', 'mangalb.ttf']
+        extra_fonts['ja'] = ['meiryo.ttc', 'meiryob.ttc', 'msgothic.ttc']
         extra_fonts['zh'] = ['msyh.ttc', 'msyhbd.ttc']
         if lang_id in extra_fonts:
             fonts_needed.extend(extra_fonts[lang_id])

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -435,6 +435,60 @@ class WinappTestCase(common.BleachbitTestCase):
 
             # cleanup
             shutil.rmtree(dirname, True)
+            
+    @common.skipUnlessWindows
+    def test_removeself(self):
+        """Test for the removeself option"""
+
+        # indexes for test
+        # position 0: FileKey statement
+        # position 1: whether the file `dir_c\subdir\foo.log` should exist after operation is complete
+        tests = (
+            # Refer to directory directly (i.e., without a glob).
+            (r'FileKey1=%s\dir_c|*.*|REMOVESELF' % self.tempdir, False),
+            # Refer to file that exists. This is invalid, so nothing happens.
+            (r'FileKey1=%s\dir_c\submarine_sandwich.log|*.*|REMOVESELF' %
+             self.tempdir, True),
+            (r'FileKey1=%s\dir_c\submarine*|*.*|REMOVESELF' % self.tempdir, True),
+            # Refer to path that does not exist, so nothing happens.
+            (r'FileKey1=%s\dir_c\doesnotexist.log|*.*|REMOVESELF' %
+             self.tempdir, True),
+            # Refer by glob to both a file and directory (which both start with `sub`).
+            # This should affect only the directory.
+            (r'FileKey1=%s\dir_c\sub*|*.*|REMOVESELF' % self.tempdir, False),
+            # glob in middle of directory path with whole directory entry
+            (r'FileKey1=%s\*c\subdir|*.*|REMOVESELF' % self.tempdir, False),
+            (r'FileKey1=%s\*doesnotexist\subdir|*.*|REMOVESELF' % self.tempdir, True),
+            # glob at end of path
+            (r'FileKey1=%s\dir_c\sub*|*.*|REMOVESELF' % self.tempdir, False),
+            (r'FileKey1=%s\dir_c\doesnotexist*|*.*|REMOVESELF' % self.tempdir, True)
+        )
+
+        (ini_h, self.ini_fn) = tempfile.mkstemp(
+            suffix='.ini', prefix='winapp2')
+        os.close(ini_h)
+
+        for filekey, c_log_expected in tests:
+            for letter in ('a', 'b', 'c'):
+                # Make three directories, each with a `foo.log` file.
+                fn = os.path.join(self.tempdir, 'dir_' +
+                                  letter, 'subdir', 'foo.log')
+                common.touch_file(fn)
+
+            # In dir_a, place a file one level up from `foo.log`.
+            # Notice the glob `dir_a\sub*` will match both a directory and file.
+            fn2 = os.path.join(self.tempdir, 'dir_a', 'submarine_sandwich.log')
+            common.touch_file(fn2)
+
+            cleaner = self.ini2cleaner(filekey)
+            self.assertExists(fn, filekey)
+            self.assertExists(fn2, filekey)
+            self.run_all(cleaner, True)
+            if c_log_expected:
+                self.assertExists(fn, filekey)
+            else:
+                self.assertNotExists(fn, filekey)
+            self.assertExists(fn2, filekey)
 
     def test_section2option(self):
         """Test for section2option()"""

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -436,60 +436,6 @@ class WinappTestCase(common.BleachbitTestCase):
             # cleanup
             shutil.rmtree(dirname, True)
 
-    @common.skipUnlessWindows
-    def test_removeself(self):
-        """Test for the removeself option"""
-
-        # indexes for test
-        # position 0: FileKey statement
-        # position 1: whether the file `dir_c\subdir\foo.log` should exist after operation is complete
-        tests = (
-            # Refer to directory directly (i.e., without a glob).
-            (r'FileKey1=%s\dir_c|*.*|REMOVESELF' % self.tempdir, False),
-            # Refer to file that exists. This is invalid, so nothing happens.
-            (r'FileKey1=%s\dir_c\submarine_sandwich.log|*.*|REMOVESELF' %
-             self.tempdir, True),
-            (r'FileKey1=%s\dir_c\submarine*|*.*|REMOVESELF' % self.tempdir, True),
-            # Refer to path that does not exist, so nothing happens.
-            (r'FileKey1=%s\dir_c\doesnotexist.log|*.*|REMOVESELF' %
-             self.tempdir, True),
-            # Refer by glob to both a file and directory (which both start with `sub`).
-            # This should affect only the directory.
-            (r'FileKey1=%s\dir_c\sub*|*.*|REMOVESELF' % self.tempdir, False),
-            # glob in middle of directory path with whole directory entry
-            (r'FileKey1=%s\*c\subdir|*.*|REMOVESELF' % self.tempdir, False),
-            (r'FileKey1=%s\*doesnotexist\subdir|*.*|REMOVESELF' % self.tempdir, True),
-            # glob at end of path
-            (r'FileKey1=%s\dir_c\sub*|*.*|REMOVESELF' % self.tempdir, False),
-            (r'FileKey1=%s\dir_c\doesnotexist*|*.*|REMOVESELF' % self.tempdir, True)
-        )
-
-        (ini_h, self.ini_fn) = tempfile.mkstemp(
-            suffix='.ini', prefix='winapp2')
-        os.close(ini_h)
-
-        for filekey, c_log_expected in tests:
-            for letter in ('a', 'b', 'c'):
-                # Make three directories, each with a `foo.log` file.
-                fn = os.path.join(self.tempdir, 'dir_' +
-                                  letter, 'subdir', 'foo.log')
-                common.touch_file(fn)
-
-            # In dir_a, place a file one level up from `foo.log`.
-            # Notice the glob `dir_a\sub*` will match both a directory and file.
-            fn2 = os.path.join(self.tempdir, 'dir_a', 'submarine_sandwich.log')
-            common.touch_file(fn2)
-
-            cleaner = self.ini2cleaner(filekey)
-            self.assertExists(fn, filekey)
-            self.assertExists(fn2, filekey)
-            self.run_all(cleaner, True)
-            if c_log_expected:
-                self.assertExists(fn, filekey)
-            else:
-                self.assertNotExists(fn, filekey)
-            self.assertExists(fn2, filekey)
-
     def test_section2option(self):
         """Test for section2option()"""
         tests = (('  FOO2  ', 'foo2'),

--- a/tests/TestWinapp.py
+++ b/tests/TestWinapp.py
@@ -435,7 +435,7 @@ class WinappTestCase(common.BleachbitTestCase):
 
             # cleanup
             shutil.rmtree(dirname, True)
-            
+
     @common.skipUnlessWindows
     def test_removeself(self):
         """Test for the removeself option"""


### PR DESCRIPTION
I did some more `winapp2.ini` related tests and was surprised that `DetectOS` didn't worked.

The reason is `Windows.get_windows_version()` which used `win32api.GetVersionEx(0)` to give a version that is being emulated for compatibility with the process, e.g. giving 6.2 for Windows 10. Now it's 10.0 instead.