### PR TITLE
.travis.yml: Fix #1302 FAIL: test_detect_encoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - export PKG_CONFIG_PATH=$VIRT_ROOT/lib/pkgconfig
 install:
   - sudo apt-get install gir1.2-gtk-3.0 gir1.2-notify-0.7 libgirepository1.0-dev libxml2-utils
-  - pip install PyGObject
+  - pip install PyGObject chardet
 # coveralls.io
   - pip install coveralls requests[security]
 # install mock


### PR DESCRIPTION
This installs the `chardet` dependency externally, although it might be better to vendor all dependecies that are not optional.

How critical is the `chardet`?

Fixes #1302.