### PR TITLE
accelerate some deep scans and safer filter for "*~" backup files

### DIFF
--- a/cleaners/deepscan.xml
+++ b/cleaners/deepscan.xml
@@ -37,8 +37,7 @@
     <label>Backup files</label>
     <description>Delete the backup files</description>
     <warning>Inspect the preview for any files you want to keep.</warning>
-    <action command="delete" search="deep" regex="\.[Bb][Aa][Kk]$"/>
-    <action command="delete" search="deep" regex="[a-zA-Z]{1,4}~$"/>
+    <action command="delete" search="deep" regex="^[^\.](Bb][Aa][Kk]|.*[a-zA-Z0-9]~)$"/>
   </option>
   <option id="ds_store">
     <label translate="false">.DS_Store</label>
@@ -50,17 +49,15 @@
     <label translate="false">Thumbs.db</label>
     <description>Delete the files</description>
     <warning>This option is slow.</warning>
-    <action command="delete" search="deep" regex="^Thumbs\.db$"/>
-    <action command="delete" search="deep" regex="^Thumbs\.db:encryptable$"/>
+    <action command="delete" search="deep" regex="^Thumbs\.db(:encryptable)?$"/>
   </option>
   <option id="tmp">
     <label>Temporary files</label>
     <description>Delete the temporary files</description>
     <warning>This option is slow.</warning>
     <!-- http://support.microsoft.com/kb/211632 -->
-    <action command="delete" search="deep" regex="^~wr[a-z][0-9]{4}\.tmp$"/>
     <!-- http://support.microsoft.com/kb/826810 -->
-    <action command="delete" search="deep" regex="^ppt[0-9]{4}\.tmp$"/>
+    <action command="delete" search="deep" regex="^(~wr[a-z]|ppt)[0-9]{4}\.tmp$"/>
   </option>
   <option id="vim_swap_user">
     <label>VIM swap files under user profile</label>
@@ -79,7 +76,6 @@ times is small.
 
 Be careful not to match files such as ~/.htpasswd
 https://github.com/bleachbit/bleachbit/issues/683
-
 -->
     <action command="delete" search="deep" regex="^.*\.sw[nop]$"/>
   </option>

--- a/tests/TestDeepScan.py
+++ b/tests/TestDeepScan.py
@@ -75,7 +75,7 @@ class DeepScanTestCase(common.BleachbitTestCase):
         """Unit test for class DeepScan.  Preview real files."""
         path = os.path.expanduser('~')
         searches = {path: []}
-        for regex in ('^Makefile$', '~$', 'bak$', '^Thumbs.db$', '^Thumbs.db:encryptable$'):
+        for regex in ('^(Makefile|Thumbs.db(:encryptable)?|bak|~)$'):
             searches[path].append(Search(command='delete', regex=regex))
         ds = DeepScan(searches)
         for cmd in ds.scan():


### PR DESCRIPTION
* Accelerate deep scans by factorizing multiple regexps for the same cleaner option to reduce the number of passes (especially on large filesystems or with mounted physical hard disks or network-mounted drives).
* Safer filter for "*~" backup files (exclude "hidden" filenames starting by a "."; if needed there should be a separate option), but also adds backup filenames ending with a digit before the "~" (e.g. "index.php7~", or "README2~")