### PR TITLE
Update TestDeepScan.py

### DIFF
--- a/tests/TestDeepScan.py
+++ b/tests/TestDeepScan.py
@@ -75,7 +75,7 @@ class DeepScanTestCase(common.BleachbitTestCase):
         """Unit test for class DeepScan.  Preview real files."""
         path = os.path.expanduser('~')
         searches = {path: []}
-        for regex in ('^Makefile$', '~$', 'bak$', '^Thumbs.db$', '^Thumbs.db:encryptable$'):
+        for regex in ('^(Makefile|Thumbs(:encryptable)?\\.db|[^.].*[0-9A-Za-z]~|bak)$'):
             searches[path].append(Search(command='delete', regex=regex))
         ds = DeepScan(searches)
         for cmd in ds.scan():


### PR DESCRIPTION
safer exclusion of `*~` backup files starting by a file, and the last character before `~` may be also a digit (e.g. `index.php7~` or `README2~`