### PR TITLE
feat: clean packages for arch and manjaro linux

### DIFF
--- a/cleaners/arch_linux.xml
+++ b/cleaners/arch_linux.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    BleachBit
+    Copyright (C) 2008-2022 Andrew Ziem
+    https://www.bleachbit.org
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<cleaner id="arch_linux" os="linux">
+  <label>Arch Linux / Manjaro</label>
+  <description>Linux Distribution</description>
+  <option id="cache">
+    <label>Package cache</label>
+    <description>Delete the Pacman cache of previously downloaded packages</description>
+    <action command="delete" search="walk.all" path="/var/cache/pacman/pkg/" />
+  </option>
+</cleaner>


### PR DESCRIPTION
## Description
I use Manjaro Linux myself and was able to verify that the cleaning process finds and deletes the correct files.

I am unsure why the CI fails on the Python v3.5 run, but all the others are passing.

## Changes
- add `arch_linux.xml` instructions for cleaning pacman cache on arch-based systems

Closes https://github.com/bleachbit/bleachbit/issues/878