### PR TITLE
Add a KDE5 folder (RecentDocuments)

### DIFF
--- a/cleaners/kde.xml
+++ b/cleaners/kde.xml
@@ -43,5 +43,6 @@
     <description>Delete the list of recently used documents</description>
     <action command="delete" search="glob" path="~/.kde/share/apps/RecentDocuments/*.desktop"/>
     <action command="delete" search="glob" path="~/.kde4/share/apps/RecentDocuments/*.desktop"/>
+    <action command="delete" search="glob" path="~/.local/share/RecentDocuments/*.desktop"/>
   </option>
 </cleaner>


### PR DESCRIPTION
* Affects at least Kubuntu 20.04 to 22.04

NOTES:
* I'm not real comfortable with obliterating ~/.cache all in one shot for KDE 5... there is a ~/.cache folder ... and has at least thunderbird *(distro installed)* which is [configured elsewhere in current thunderbird.xml](https://github.com/bleachbit/bleachbit/blob/ff06d09a89072dc064e97816ae81b43788610f66/cleaners/thunderbird.xml#L42) cleaner ... so skipping
* I don't see any kind of general .tmp in my user profile *(~)* ... so skipping
* This only clears the cached *(written)* list and **not** the in-memory *(Note these persist somewhere hidden atm between reboots/sessions)* "Places" *(22.04.x)* and "History" *(20.04.x)*

Historical refs:
* #130
* https://github.com/bleachbit/bleachbit/commit/78684e510c7334392b991f3a7efc5e435cf3cd3e
* https://github.com/bleachbit/bleachbit/commit/ae95d012f560a0fb970122ca741ad6fef114a815
* https://github.com/bleachbit/bleachbit/commit/aec8ac1b4b8ab10e430f5b8297ecd1c74df9d1a5