### PR TITLE
Fix the detection of invalid .desktop files

### DIFF
--- a/bleachbit/Cleaner.py
+++ b/bleachbit/Cleaner.py
@@ -382,10 +382,10 @@ class System(Cleaner):
                      '~/.kde2/share/applnk']
 
         if 'posix' == os.name and 'desktop_entry' == option_id:
-            for dirname in menu_dirs:
-                for filename in [fn for fn in children_in_directory(dirname, False)
-                                 if fn.endswith('.desktop')]:
-                    if Unix.is_broken_xdg_desktop(filename):
+            for path in menu_dirs:
+                dirname = os.path.expanduser(path)
+                for filename in children_in_directory(dirname, False):
+                    if filename.endswith('.desktop') and Unix.is_broken_xdg_desktop(filename):
                         yield Command.Delete(filename)
 
         # unwanted locales


### PR DESCRIPTION
```
[nix-shell:~/Projects/bleachbit]$ python bleachbit.py --preview system.desktop_entry
is_broken_xdg_menu: executable 'run_keybase' does not exist '/home/kenman/.config/autostart/keybase_autostart.desktop'
Delete 4.1kB /home/kenman/.config/autostart/keybase_autostart.desktop
Disk space to be recovered: 4.1kB
Files to be deleted: 1
```

@abitrolly I'm not sure if it was because of `env` existing. After debugging it, it seemed that none of the `menu_dirs` were working because of using `~/` as home directory. May I have you test this from my PR's branch please?

Otherwise, closes #1067