### PR TITLE
cli: Reorder entries in `--help`

### DIFF
--- a/bleachbit/CLI.py
+++ b/bleachbit/CLI.py
@@ -147,20 +147,25 @@ def process_cmd_line():
     parser = optparse.OptionParser(usage)
     parser.add_option("-l", "--list-cleaners", action="store_true",
                       help=_("list cleaners"))
+    parser.add_option("-p", "--preview", action="store_true",
+                      help=_("preview files to be deleted and other changes"))
     parser.add_option("-c", "--clean", action="store_true",
                       # TRANSLATORS: predefined cleaners are for applications, such as Firefox and Flash.
                       # This is different than cleaning an arbitrary file, such as a
                       # spreadsheet on the desktop.
                       help=_("run cleaners to delete files and make other permanent changes"))
-    parser.add_option(
-        '--debug', help=_("set log level to verbose"), action="store_true")
-    parser.add_option('--debug-log', help=_("log debug messages to file"))
     parser.add_option("-s", "--shred", action="store_true",
                       help=_("shred specific files or folders"))
-    parser.add_option("--sysinfo", action="store_true",
-                      help=_("show system information"))
+    parser.add_option("-w", "--wipe-free-space", action="store_true",
+                      help=_("wipe free space in the given paths"))
+    parser.add_option('-o', '--overwrite', action='store_true',
+                      help=_('overwrite files to hide contents'))
     parser.add_option("--gui", action="store_true",
                       help=_("launch the graphical interface"))
+    parser.add_option("--preset", action="store_true",
+                      help=_("use options set in the graphical interface"))
+    # option for testing py2exe build
+    # https://github.com/bleachbit/bleachbit/commit/befe244efee9b2d4859c6b6c31f8bedfd4d85aad#diff-b578cd35e15095f69822ebe497bf8691da1b587d6cc5f5ec252ff4f186dbed56
     parser.add_option('--exit', action='store_true',
                       help=optparse.SUPPRESS_HELP)
 
@@ -169,23 +174,20 @@ def process_cmd_line():
     else:
         uac_help = optparse.SUPPRESS_HELP
     parser.add_option("--no-uac", action="store_true", help=uac_help)
-    parser.add_option("-p", "--preview", action="store_true",
-                      help=_("preview files to be deleted and other changes"))
     parser.add_option('--pot', action='store_true',
                       help=optparse.SUPPRESS_HELP)
-    parser.add_option("--preset", action="store_true",
-                      help=_("use options set in the graphical interface"))
     parser.add_option("--all-but-warning", action="store_true",
                       help=_("enable all options that do not have a warning"))
     if 'nt' == os.name:
         parser.add_option("--update-winapp2", action="store_true",
                           help=_("update winapp2.ini, if a new version is available"))
-    parser.add_option("-w", "--wipe-free-space", action="store_true",
-                      help=_("wipe free space in the given paths"))
+    parser.add_option(
+        '--debug', help=_("set log level to verbose"), action="store_true")
+    parser.add_option('--debug-log', help=_("log debug messages to file"))
+    parser.add_option("--sysinfo", action="store_true",
+                      help=_("show system information"))
     parser.add_option("-v", "--version", action="store_true",
                       help=_("output version information and exit"))
-    parser.add_option('-o', '--overwrite', action='store_true',
-                      help=_('overwrite files to hide contents'))
 
     def expand_context_menu_option(option, opt, value, parser):
         setattr(parser.values, 'gui', True)


### PR DESCRIPTION
Before.
```
Usage: bleachbit.py [options] cleaner.option1 cleaner.option2

Options:
  -h, --help            show this help message and exit
  -l, --list-cleaners   list cleaners
  -c, --clean           run cleaners to delete files and make other permanent
                        changes
  --debug               set log level to verbose
  --debug-log=DEBUG_LOG
                        log debug messages to file
  -s, --shred           shred specific files or folders
  --sysinfo             show system information
  --gui                 launch the graphical interface
  -p, --preview         preview files to be deleted and other changes
  --preset              use options set in the graphical interface
  --all-but-warning     enable all options that do not have a warning
  -w, --wipe-free-space
                        wipe free space in the given paths
  -v, --version         output version information and exit
  -o, --overwrite       overwrite files to hide contents
  --context-menu
```
After.
```
Usage: bleachbit.py [options] cleaner.option1 cleaner.option2

Options:
  -h, --help            show this help message and exit
  -l, --list-cleaners   list cleaners
  -p, --preview         preview files to be deleted and other changes
  -c, --clean           run cleaners to delete files and make other permanent
                        changes
  -s, --shred           shred specific files or folders
  -w, --wipe-free-space
                        wipe free space in the given paths
  -o, --overwrite       overwrite files to hide contents
  --gui                 launch the graphical interface
  --preset              use options set in the graphical interface
  --all-but-warning     enable all options that do not have a warning
  --debug               set log level to verbose
  --debug-log=DEBUG_LOG
                        log debug messages to file
  --sysinfo             show system information
  -v, --version         output version information and exit
  --context-menu
```