### PR TITLE
cli: Suppress `--context-menu` option from help output

### DIFF
--- a/bleachbit/CLI.py
+++ b/bleachbit/CLI.py
@@ -164,23 +164,8 @@ def process_cmd_line():
                       help=_("launch the graphical interface"))
     parser.add_option("--preset", action="store_true",
                       help=_("use options set in the graphical interface"))
-    # option for testing py2exe build
-    # https://github.com/bleachbit/bleachbit/commit/befe244efee9b2d4859c6b6c31f8bedfd4d85aad#diff-b578cd35e15095f69822ebe497bf8691da1b587d6cc5f5ec252ff4f186dbed56
-    parser.add_option('--exit', action='store_true',
-                      help=optparse.SUPPRESS_HELP)
-
-    if 'nt' == os.name:
-        uac_help = _("do not prompt for administrator privileges")
-    else:
-        uac_help = optparse.SUPPRESS_HELP
-    parser.add_option("--no-uac", action="store_true", help=uac_help)
-    parser.add_option('--pot', action='store_true',
-                      help=optparse.SUPPRESS_HELP)
     parser.add_option("--all-but-warning", action="store_true",
                       help=_("enable all options that do not have a warning"))
-    if 'nt' == os.name:
-        parser.add_option("--update-winapp2", action="store_true",
-                          help=_("update winapp2.ini, if a new version is available"))
     parser.add_option(
         '--debug', help=_("set log level to verbose"), action="store_true")
     parser.add_option('--debug-log', help=_("log debug messages to file"))
@@ -189,11 +174,28 @@ def process_cmd_line():
     parser.add_option("-v", "--version", action="store_true",
                       help=_("output version information and exit"))
 
+    # option for testing py2exe build
+    # https://github.com/bleachbit/bleachbit/commit/befe244efee9b2d4859c6b6c31f8bedfd4d85aad#diff-b578cd35e15095f69822ebe497bf8691da1b587d6cc5f5ec252ff4f186dbed56
+    parser.add_option('--exit', action='store_true',
+                      help=optparse.SUPPRESS_HELP)
+    if 'nt' == os.name:
+        uac_help = _("do not prompt for administrator privileges")
+    else:
+        uac_help = optparse.SUPPRESS_HELP
+    parser.add_option("--no-uac", action="store_true", help=uac_help)
+    parser.add_option('--pot', action='store_true',
+                      help=optparse.SUPPRESS_HELP)
+    if 'nt' == os.name:
+        parser.add_option("--update-winapp2", action="store_true",
+                          help=_("update winapp2.ini, if a new version is available"))
+
+    # some workaround for context menu added here
+    # https://github.com/bleachbit/bleachbit/commit/b09625925149c98a6c79e278c35d5995e7526993
     def expand_context_menu_option(option, opt, value, parser):
         setattr(parser.values, 'gui', True)
         setattr(parser.values, 'exit', True)
-
-    parser.add_option("--context-menu", action="callback", callback=expand_context_menu_option)
+    parser.add_option("--context-menu", action="callback", callback=expand_context_menu_option,
+                      help=optparse.SUPPRESS_HELP)
 
     (options, args) = parser.parse_args()
 

--- a/bleachbit/CLI.py
+++ b/bleachbit/CLI.py
@@ -174,10 +174,6 @@ def process_cmd_line():
     parser.add_option("-v", "--version", action="store_true",
                       help=_("output version information and exit"))
 
-    # option for testing py2exe build
-    # https://github.com/bleachbit/bleachbit/commit/befe244efee9b2d4859c6b6c31f8bedfd4d85aad#diff-b578cd35e15095f69822ebe497bf8691da1b587d6cc5f5ec252ff4f186dbed56
-    parser.add_option('--exit', action='store_true',
-                      help=optparse.SUPPRESS_HELP)
     if 'nt' == os.name:
         uac_help = _("do not prompt for administrator privileges")
     else:
@@ -188,6 +184,11 @@ def process_cmd_line():
     if 'nt' == os.name:
         parser.add_option("--update-winapp2", action="store_true",
                           help=_("update winapp2.ini, if a new version is available"))
+
+    # added for testing py2exe build
+    # https://github.com/bleachbit/bleachbit/commit/befe244efee9b2d4859c6b6c31f8bedfd4d85aad#diff-b578cd35e15095f69822ebe497bf8691da1b587d6cc5f5ec252ff4f186dbed56
+    parser.add_option('--exit', action='store_true',
+                      help=optparse.SUPPRESS_HELP)
 
     # some workaround for context menu added here
     # https://github.com/bleachbit/bleachbit/commit/b09625925149c98a6c79e278c35d5995e7526993


### PR DESCRIPTION
Reorders hidden flags towards the end and hides `--context-menu`.

I didn't spend much time looking into why `--context-menu` adds `--exit` and `--gui`, so just adding a comment here to make it easier to research later.