### PR TITLE
Debug build for long BleachBit names in Windows UI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,14 +101,14 @@ if 'py2exe' in sys.argv:
     args['windows'] = [{
         'script': 'bleachbit.py',
         'product_name': APP_NAME,
-        'description': APP_DESCRIPTION,
+        'description': '[windows] ' + APP_DESCRIPTION,
         'version': bleachbit.APP_VERSION,
         'icon_resources': [(1, 'windows/bleachbit.ico')]
     }]
     args['console'] = [{
         'script': 'bleachbit_console.py',
         'product_name': APP_NAME,
-        'description': APP_DESCRIPTION,
+        'description': '[console] ' + APP_DESCRIPTION,
         'version': bleachbit.APP_VERSION,
         'icon_resources': [(1, 'windows/bleachbit.ico')]
     }]
@@ -263,7 +263,7 @@ def run_setup():
     setup(name='bleachbit',
           version=bleachbit.APP_VERSION,
           description=APP_NAME,
-          long_description=APP_DESCRIPTION,
+          long_description='[setup.py] ' + APP_DESCRIPTION,
           author="Andrew Ziem",
           author_email="andrew@bleachbit.org",
           download_url="https://www.bleachbit.org/download",


### PR DESCRIPTION
As described in https://github.com/bleachbit/bleachbit/issues/1109#issuecomment-1304842375 this will produce AppVeyor binaries that will tell where the long name for BleachBit in #1000 #1109 #1134 comes from.

**EDIT**: Binaries are there https://ci.appveyor.com/project/az0/bleachbit/builds/45293024/artifacts and will expire in a month.

Attaching for backups.

[BleachBit-4.4.2.2275-portable.zip](https://github.com/bleachbit/bleachbit/files/9946711/BleachBit-4.4.2.2275-portable.zip)
[BleachBit-4.4.2.2275-setup.exe.zip](https://github.com/bleachbit/bleachbit/files/9946763/BleachBit-4.4.2.2275-setup.exe.zip)
[BleachBit-4.4.2.2275-setup-English.exe.zip](https://github.com/bleachbit/bleachbit/files/9946764/BleachBit-4.4.2.2275-setup-English.exe.zip)
