### PR TITLE
Fix typos

### DIFF
--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -503,10 +503,10 @@ def is_running_darwin(exename):
     try:
         ps_out = subprocess.check_output(["ps", "aux", "-c"],
                                          universal_newlines=True)
-        processess = (re.split(r"\s+", p, 10)[10]
+        processes = (re.split(r"\s+", p, 10)[10]
                       for p in ps_out.split("\n") if p != "")
-        next(processess)  # drop the header
-        return exename in processess
+        next(processes)  # drop the header
+        return exename in processes
     except IndexError:
         raise RuntimeError("Unexpected output from ps")
 

--- a/bleachbit/WindowsWipe.py
+++ b/bleachbit/WindowsWipe.py
@@ -124,7 +124,7 @@ VER_SUITE_PERSONAL = 0x200   # doesn't seem to be present in win32con.
 
 # Constants.
 simulate_concurrency = False     # remove this test function when QA complete
-# drive_letter_safety = "E"       # protection to only use removeable drives
+# drive_letter_safety = "E"       # protection to only use removable drives
 # don't use C: or D:, but E: and beyond OK.
 tmp_file_name = "bbtemp.dat"
 spike_file_name = "bbspike"     # cluster number will be appended

--- a/bleachbit/_platform.py
+++ b/bleachbit/_platform.py
@@ -5,7 +5,7 @@
 
     If called from the command line, it prints the platform
     information concatenated as single string to stdout. The output
-    format is useable as part of a filename.
+    format is usable as part of a filename.
 
 """
 #    This module is maintained by Marc-Andre Lemburg <mal@egenix.com>.

--- a/tests/TestWorker.py
+++ b/tests/TestWorker.py
@@ -260,7 +260,7 @@ class WorkerTestCase(common.BleachbitTestCase):
             bytes_expected = 3 + 3
             total_deleted = 2
         else:
-            # If not an admin, the first attempt will fail, and the second wil succeed.
+            # If not an admin, the first attempt will fail, and the second will succeed.
             errors_expected = 1
             bytes_expected = 3
             total_deleted = 1


### PR DESCRIPTION
Found via `codespell -S themes,windows,po -L vie,ro,te,jist,mot,mor,ore,pres`