### PR TITLE
Fixes #441

### DIFF
--- a/bleachbit/GUI.py
+++ b/bleachbit/GUI.py
@@ -440,9 +440,9 @@ class TreeInfoModel:
                                                               self.on_row_changed)
 
     def sort_func(self, model, iter1, iter2, _user_data):
-        """Sort the tree by the display name"""
-        value1 = model[iter1][0].lower()
-        value2 = model[iter2][0].lower()
+        """Sort the tree by the id"""
+        value1 = model[iter1][2].lower()
+        value2 = model[iter2][2].lower()
         if value1 == value2:
             return 0
         if value1 > value2:


### PR DESCRIPTION
Sort the cleaners by Id (instead of localized display name) so that the sort sequence is consistent across all languages, and specifically the "Vacuum" option gets executed at the end.