### PR TITLE
journald: preview, rotate and code comments

### DIFF
--- a/bleachbit/Action.py
+++ b/bleachbit/Action.py
@@ -490,7 +490,7 @@ class Cookie(FileActionProvider):
                 path,
                 delete_func,
                 _('Clean cookies'),
-                preview_func)
+                preview_func=preview_func)
 
     def _load_keep_list(self):
         """Load cookie domains to keep from options directory.

--- a/bleachbit/Action.py
+++ b/bleachbit/Action.py
@@ -562,7 +562,7 @@ class Ini(FileActionProvider):
 
 
 class Journald(ActionProvider):
-    """Action to run 'journalctl --vacuum-time=1'"""
+    """Action to run 'journalctl --rotate --vacuum-size=1'"""
     action_key = 'journald.clean'
 
     def __init__(self, action_element, path_vars=None):
@@ -572,7 +572,9 @@ class Journald(ActionProvider):
         # If journalctl is not installed, then enable fast auto-hide.
         if not FileUtilities.exe_exists('journalctl'):
             return
-        yield Command.Function(None, Unix.journald_clean, 'journalctl --vacuum-time=1')
+        yield Command.Function(None,
+                               Unix.journald_clean,
+                               'journalctl --rotate --vacuum-size=1')
 
 
 class Json(FileActionProvider):

--- a/bleachbit/Action.py
+++ b/bleachbit/Action.py
@@ -574,7 +574,8 @@ class Journald(ActionProvider):
             return
         yield Command.Function(None,
                                Unix.journald_clean,
-                               'journalctl --rotate --vacuum-size=1')
+                               'journalctl --rotate --vacuum-size=1',
+                               preview_func=Unix.journald_preview)
 
 
 class Json(FileActionProvider):

--- a/bleachbit/Command.py
+++ b/bleachbit/Command.py
@@ -129,7 +129,7 @@ class Function:
         Parameters:
             path (str or None): Path to file or None if function doesn't operate on a file
             func (function): Function to execute that takes path or returns size
-            label (str): Label for display in the UI
+            label (str): Label for log output (for UI label see cleaner XML file)
             preview_func (function, optional): Function to call in preview mode
 
         func and preview_func take no arguments and return an integer.

--- a/bleachbit/Command.py
+++ b/bleachbit/Command.py
@@ -167,13 +167,15 @@ class Function:
             'size': None}
 
         if not really_delete and self.preview_func is not None:
-            # Preview mode: call preview function to get list of items that would be deleted
+            # Preview mode: call preview function to get size of items that would be deleted
             try:
-                preview_items = self.preview_func()
-                if isinstance(preview_items, int):
-                    ret['size'] = preview_items
+                preview = self.preview_func()
             except Exception as e:
                 logger.warning(f'Preview function failed: {e}')
+            if isinstance(preview, int):
+                ret['size'] = preview
+            else:
+                logger.warning(f'Preview function returned non-int value: {preview}')
                 ret['size'] = 0
         elif really_delete:
             if self.path is None:

--- a/bleachbit/Command.py
+++ b/bleachbit/Command.py
@@ -123,7 +123,7 @@ class Function:
 
     """Execute a simple Python function"""
 
-    def __init__(self, path, func, label, preview_func=None):
+    def __init__(self, path, func, label, *, preview_func=None):
         """Initialize a Function command
 
         Parameters:

--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -601,6 +601,16 @@ def run_cleaner_cmd(cmd, args, freed_space_regex=r'[\d.]+[kMGTE]?B?', error_line
     return freed_space
 
 
+def journald_preview():
+    (rc, stdout, stderr) = General.run_external(['journalctl', '--disk-usage'])
+    if rc != 0:
+        raise RuntimeError(f'`journalctl --disk-usage` raised error {rc}: {stderr}')
+    human_size = stdout.strip() \
+                 .removeprefix('Archived and active journals take up ') \
+                 .removesuffix(' in the file system.')
+    return FileUtilities.human_to_bytes(human_size)
+
+
 def journald_clean():
     """Clean the system journals"""
     try:

--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -604,7 +604,7 @@ def run_cleaner_cmd(cmd, args, freed_space_regex=r'[\d.]+[kMGTE]?B?', error_line
 def journald_clean():
     """Clean the system journals"""
     try:
-        return run_cleaner_cmd('journalctl', ['--vacuum-size=1'], JOURNALD_REGEX)
+        return run_cleaner_cmd('journalctl', ['--rotate', '--vacuum-size=1'], JOURNALD_REGEX)
     except subprocess.CalledProcessError as e:
         raise RuntimeError(
             f"Error calling '{' '.join(e.cmd)}':\n{e.output}") from e


### PR DESCRIPTION
**UPDATE:** This adds preview for disk usage occupied by journal files that is reported by `journalctl --disk-usage`.

`--disk-usage` reports both active and archived files space, but `--vacuum-size=1` only operates on archives, so the PR adds `--rotate` flag to archive active entries before vacuuming.