### PR TITLE
Clean Firefox installed as flatpak

### DIFF
--- a/cleaners/firefox.xml
+++ b/cleaners/firefox.xml
@@ -28,10 +28,12 @@
   <running type="exe" os="windows">firefox.exe</running>
   <running type="pathname">~/.mozilla/firefox/*.default/lock</running>
   <running type="pathname">~/snap/firefox/common/.mozilla/firefox/*.default/lock</running>
+  <running type="pathname">~/.var/app/org.mozilla.firefox/.mozilla/firefox/*.default*/lock</running> <!-- Flatpak -->
   <var name="base">
     <value os="windows">%AppData%\Mozilla\Firefox</value>
     <value os="linux">~/.mozilla/firefox</value>
     <value os="linux">~/snap/firefox/common/.mozilla/firefox</value>
+    <value os="linux">~/.var/app/org.mozilla.firefox/.mozilla/firefox</value> <!-- Flatpak -->
     <value os="freebsd">~/.mozilla/firefox</value>
     <value os="openbsd">~/.mozilla/firefox</value>
   </var>
@@ -39,6 +41,7 @@
     <value search="glob" os="windows">%AppData%\Mozilla\Firefox\Profiles\*</value>
     <value search="glob" os="linux">~/.mozilla/firefox/*</value>
     <value search="glob" os="linux">~/snap/firefox/common/.mozilla/firefox/*</value>
+    <value search="glob" os="linux">~/.var/app/org.mozilla.firefox/.mozilla/firefox/*</value> <!-- Flatpak -->
     <value search="glob" os="freebsd">~/.mozilla/firefox/*</value>
     <value search="glob" os="openbsd">~/.mozilla/firefox/*</value>
   </var>
@@ -57,6 +60,7 @@ redundant. Also, this Linux path contains the cache2 and OfflineCache directorie
 -->
     <action command="delete" search="walk.all" path="~/.cache/mozilla/"/>
     <action command="delete" search="walk.all" path="~/snap/firefox/common/.cache/mozilla/"/>
+    <action command="delete" search="walk.all" path="~/.var/app/org.mozilla.firefox/cache/mozilla/"/> <!-- Flatpak -->
     <action command="delete" search="walk.all" path="%LocalAppData%\Mozilla\Firefox\Profiles\*\cache2"/>
     <action command="delete" search="walk.all" path="%LocalAppData%\Mozilla\Firefox\Profiles\*\jumpListCache"/>
     <action command="delete" search="walk.all" path="%LocalAppData%\Mozilla\Firefox\Profiles\*\OfflineCache"/>


### PR DESCRIPTION
Hi, this pull request is for adding support for firefox flatpak. I have done a little bit of testing and it seams to work fine on my side.

At line 31 after `.default` I have added a `*` wildcard in order to match `xxxxxxxx.default-release`