### PR TITLE
Update org.bleachbit.BleachBit.desktop

### DIFF
--- a/org.bleachbit.BleachBit.desktop
+++ b/org.bleachbit.BleachBit.desktop
@@ -123,4 +123,5 @@ Icon=bleachbit
 Categories=System;FileTools;GTK;
 Keywords=cache;clean;free;performance;privacy;
 StartupNotify=true
+StartupWMClass=bleachbit
 X-GNOME-UsesNotifications=true


### PR DESCRIPTION
Implemented icon resolution fix by adding StartupWMClass=bleachbit to the .desktop file. This ensures the correct icon is displayed in the application launcher instead of the default blue icon. Tested on my system (archlinux), and the icon now appears as expected.