### PR TITLE
Fix startup error on Python 3.12

### DIFF
--- a/bleachbit/__init__.py
+++ b/bleachbit/__init__.py
@@ -30,7 +30,7 @@ import sys
 import platform
 
 from bleachbit import Log
-from configparser import RawConfigParser, NoOptionError, SafeConfigParser
+from configparser import RawConfigParser, NoOptionError
 
 APP_VERSION = "4.5.0"
 APP_NAME = "BleachBit"


### PR DESCRIPTION
`SafeConfigParser` was removed in Python 3.12, but there's nothing in the codebase using it anyway.
