### PR TITLE
use a more compatible way to determine the session type

### DIFF
--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -728,10 +728,7 @@ def dnf_autoremove():
 
 def is_linux_display_protocol_wayland():
     assert(sys.platform.startswith('linux'))
-    result = General.run_external(['loginctl'])
-    session = result[1].split('\n')[1].strip().split(' ')[0]
-    result = General.run_external(['loginctl', 'show-session', session, '-p', 'Type'])
-    return 'wayland' in result[1].lower()
+    return os.environ['XDG_SESSION_TYPE'] == 'wayland'
 
 
 def root_is_not_allowed_to_X_session():

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -313,17 +313,12 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
     @common.skipIfWindows
     def test_is_linux_display_protocol_wayland(self):
         display_protocol = None
-        def side_effect_func(value):
-            if len(value) == 1:
-                return (0, 'SESSION  UID USER   SEAT  TTY \n      2 1000 debian seat0 tty2\n\n1 sessions listed.\n', '')
-            elif len(value) > 1:
-                return (0, 'Type={}\n'.format(display_protocol), '')
-            assert(False) # should never reach here
 
         for display_protocol, assert_method in [['wayland', self.assertTrue], ['donotexist', self.assertFalse]]:
-            with mock.patch('bleachbit.General.run_external') as mock_run_external:
-                mock_run_external.side_effect = side_effect_func
-                is_wayland = is_linux_display_protocol_wayland()
+            os.environ['XDG_SESSION_TYPE'] = 'wayland'
+            is_wayland = is_linux_display_protocol_wayland()
+            del os.environ['XDG_SESSION_TYPE']
+
             self.assertIsInstance(is_wayland, bool)
             assert_method(is_wayland)
 


### PR DESCRIPTION
Use the environment variable`XDG_SESSION_ID` to determine the session type instead of invoking a command. This variable is also populated by systemd-logind. However, it can be filled by the host system if bleachbit is running in a sandbox without systemd in the sandbox.

Fixes https://github.com/flathub/org.bleachbit.BleachBit/issues/13