### PR TITLE
Fix 1626 - initial implementation, feedback needed.

### DIFF
--- a/bleachbit/GUI.py
+++ b/bleachbit/GUI.py
@@ -528,13 +528,13 @@ class TreeDisplayModel:
                                                _('Confirm'))
                 if Gtk.ResponseType.OK != resp:
                     # user cancelled, so don't toggle option
-                    return None, None
+                    return None
                 
             elif warning and all_toggled:
                 return msg, path
                 
         model[path][1] = value
-        return None, None
+        return None
         
 
     def col1_toggled_cb(self, cell, path, model, parent_window):
@@ -566,7 +566,7 @@ class TreeDisplayModel:
         msgs_paths = []
         while child:
             msg_path = self.set_cleaner(child, model, parent_window, is_toggled_on, all_toggled)
-            if msg_path is not (None, None):
+            if msg_path is not None:
                 msgs_paths.append(msg_path)
             child = model.iter_next(child)
             
@@ -1250,12 +1250,15 @@ class GUI(Gtk.ApplicationWindow):
         hbox_select_buttons = Gtk.Box(homogeneous=False)
         hbox_select_buttons.add(self._select_all_button)
         hbox_select_buttons.add(self._deselect_all_button)
-        vbox.add(hbox_select_buttons)
+        # vbox.add(hbox_select_buttons)
         vbox.add(hbox)
 
         # add operations to left
+        vbox_operations = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, homogeneous=False)
         operations = self.create_operations_box()
-        hbox.pack_start(operations, False, True, 0)
+        vbox_operations.pack_start(hbox_select_buttons, False, False, 0)
+        vbox_operations.pack_start(operations, True, True, 0)
+        hbox.pack_start(vbox_operations, False, True, 0)
 
         # create the right side of the window
         right_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)

--- a/bleachbit/GUI.py
+++ b/bleachbit/GUI.py
@@ -742,6 +742,13 @@ class GUI(Gtk.ApplicationWindow):
         self.run_button.set_sensitive(is_sensitive)
         self.stop_button.set_sensitive(not is_sensitive)
 
+    def select_all_toggled(self, select_all_checkbox):
+        if select_all_checkbox.get_active():
+            print('select all')
+        else:
+            print('de-select all')
+
+
     def run_operations(self, __widget):
         """Event when the 'delete' toolbar button is clicked."""
         # fixme: should present this dialog after finding operations
@@ -1192,10 +1199,18 @@ class GUI(Gtk.ApplicationWindow):
         self.headerbar = self.create_headerbar()
         self.set_titlebar(self.headerbar)
 
+        check_box_container = Gtk.Box(homogeneous=False)
+        # self.add(check_box_container)
+
+        self._select_all_checkbox = Gtk.CheckButton(label="Select all")
+        self._select_all_checkbox.connect("toggled", self.select_all_toggled)
+        # check_box_container.pack_end(self._select_all_checkbox, True, True, 0)
+
         # split main window twice
         hbox = Gtk.Box(homogeneous=False)
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, homogeneous=False)
         self.add(vbox)
+        vbox.add(self._select_all_checkbox)
         vbox.add(hbox)
 
         # add operations to left

--- a/bleachbit/GUI.py
+++ b/bleachbit/GUI.py
@@ -528,13 +528,13 @@ class TreeDisplayModel:
                                                _('Confirm'))
                 if Gtk.ResponseType.OK != resp:
                     # user cancelled, so don't toggle option
-                    return None
+                    return None, None
                 
             elif warning and all_toggled:
                 return msg, path
                 
         model[path][1] = value
-        return None
+        return None, None
         
 
     def col1_toggled_cb(self, cell, path, model, parent_window):
@@ -563,22 +563,24 @@ class TreeDisplayModel:
                 model[parent][1] = False
         # If toggled and has children, then do the same for each child.
         child = model.iter_children(i)
-        path_to_msg = {}
+        msgs_paths = []
         while child:
             msg_path = self.set_cleaner(child, model, parent_window, is_toggled_on, all_toggled)
-            if msg_path is not None:
-                path_to_msg[msg_path[1]] = msg_path[0]
+            if msg_path is not (None, None):
+                msgs_paths.append(msg_path)
             child = model.iter_next(child)
             
-        if path_to_msg:
-            msgs = '\n\n'.join(path_to_msg.values())
+        if msgs_paths:
+            msgs = list(zip(*msgs_paths))[0]
+            msgs = '\n\n'.join(msgs)
             resp = GuiBasic.message_dialog(parent_window,
                                 msgs,
                                 Gtk.MessageType.WARNING,
                                 Gtk.ButtonsType.OK_CANCEL,
                                 _('Confirm'))
             if Gtk.ResponseType.OK == resp:
-                for path in path_to_msg.keys():
+                paths = list(zip(*msgs_paths))[1]
+                for path in paths:
                     model[path][1] = True
             
         return

--- a/bleachbit/GUI.py
+++ b/bleachbit/GUI.py
@@ -743,10 +743,16 @@ class GUI(Gtk.ApplicationWindow):
         self.stop_button.set_sensitive(not is_sensitive)
 
     def select_all_toggled(self, select_all_checkbox):
-        if select_all_checkbox.get_active():
-            print('select all')
-        else:
-            print('de-select all')
+
+        print('select all')
+        count = 0
+        model = self.tree_store.get_model()
+        iterator = model.iter_children()
+        while iterator:
+            self.display.col1_toggled_cb(None, str(count), model, self)
+            iterator = model.iter_next(iterator)
+            count += 1
+
 
 
     def run_operations(self, __widget):
@@ -819,9 +825,9 @@ class GUI(Gtk.ApplicationWindow):
             Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled_window.set_overlay_scrolling(False)
         self.tree_store = TreeInfoModel()
-        display = TreeDisplayModel()
+        self.display = TreeDisplayModel()
         mdl = self.tree_store.get_model()
-        self.view = display.make_view(
+        self.view = self.display.make_view(
             mdl, self, self.context_menu_event)
         self.view.get_selection().connect("changed", self.on_selection_changed)
         scrollbar_width = scrolled_window.get_vscrollbar().get_preferred_width()[1]

--- a/tests/TestAll.py
+++ b/tests/TestAll.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
     python -m unittest tests.TestCLI                              # run only the CLI tests
     python -m unittest tests.TestCLI.CLITestCase.test_encoding    # run only a single test""")
     suite = unittest.defaultTestLoader.discover(
-        os.getcwd(), pattern='Test*.py')
+        os.getcwd(), pattern='TestGUI*.py')
     success = unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()
     
     del os.environ['BLEACHBIT_TEST_OPTIONS_DIR']

--- a/tests/TestAll.py
+++ b/tests/TestAll.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
     python -m unittest tests.TestCLI                              # run only the CLI tests
     python -m unittest tests.TestCLI.CLITestCase.test_encoding    # run only a single test""")
     suite = unittest.defaultTestLoader.discover(
-        os.getcwd(), pattern='TestGUI*.py')
+        os.getcwd(), pattern='Test*.py')
     success = unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful()
     
     del os.environ['BLEACHBIT_TEST_OPTIONS_DIR']

--- a/tests/TestGUI.py
+++ b/tests/TestGUI.py
@@ -295,3 +295,26 @@ class GUITestCase(common.BleachbitTestCase):
 
             self.refresh_gui()
             assert_method(file_to_clean)
+
+    def _get_checkmark_state_for_cleaner(self, gui, cleaner_id, option_id):
+        # todo clean duplication with set_checkmark...
+        model = gui.view.get_model()
+        tree = self.find_widget(gui, Gtk.TreeView)
+        self.assertIsNotNone(tree)
+        it = self.find_option(model, cleaner_id, option_id)
+        self.assertIsNotNone(it)
+        tree.scroll_to_cell(model.get_path(it), None, False, 0, 0)
+        parent_check_mark_state = model[model.iter_parent(it)][1]
+        checkmark_state = model[it][1]
+        return parent_check_mark_state, checkmark_state
+
+    def test_select_all_no_warning(self):
+        gui = self.app._window
+        file_to_clean = self._setup_new_cleaner(gui)
+        gui._select_all_checkbox.set_active(True)
+        self.refresh_gui()
+        gui = self.app._window
+        parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(
+            gui, self._NEW_CLEANER_ID, self._NEW_OPTION_ID)
+        self.assertTrue(parent_check_mark_state)
+        self.assertTrue(checkmark_state)

--- a/tests/TestGUI.py
+++ b/tests/TestGUI.py
@@ -339,7 +339,6 @@ class GUITestCase(common.BleachbitTestCase):
     
     def test_select_all_based_on_existing_selection(self):
         with mock.patch('bleachbit.system_cleaners_dir', self._dirname):
-            from bleachbit.Cleaner import backends
             self._setup_new_cleaner(self._dirname, self._cleaner_id, self._option_id)
             self._setup_new_cleaner(self._dirname, self._cleaner_id_2, self._option_id_2)
             
@@ -354,7 +353,6 @@ class GUITestCase(common.BleachbitTestCase):
        
     def test_deselect_all_based_on_existing_selection(self):    
         with mock.patch('bleachbit.system_cleaners_dir', self._dirname):
-            from bleachbit.Cleaner import backends
             self._setup_new_cleaner(self._dirname, self._cleaner_id, self._option_id)
             self._setup_new_cleaner(self._dirname, self._cleaner_id_2, self._option_id_2)
             

--- a/tests/TestGUI.py
+++ b/tests/TestGUI.py
@@ -311,7 +311,7 @@ class GUITestCase(common.BleachbitTestCase):
     def test_select_all_no_warning(self):
         gui = self.app._window
         file_to_clean = self._setup_new_cleaner(gui)
-        gui._select_all_checkbox.set_active(True)
+        gui._select_all_button.emit("pressed")
         self.refresh_gui()
         gui = self.app._window
         parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(

--- a/tests/TestGUI.py
+++ b/tests/TestGUI.py
@@ -51,7 +51,6 @@ bleachbit.online_update_notification_enabled = False
 class GUITestCase(common.BleachbitTestCase):
     app = Bleachbit(auto_exit=False, uac=False)
     options_get_tree = options.get_tree
-    _NEW_CLEANER_ID, _NEW_OPTION_ID = 'test_run_operations', 'test1'
 
     """Test case for module GUI"""
     @classmethod
@@ -231,38 +230,37 @@ class GUITestCase(common.BleachbitTestCase):
         for obj in test_files_dirs:
             self.assertNotExists(obj)
 
-    @mock.patch('bleachbit.CleanerML.list_cleanerml_files')
+    # @mock.patch('bleachbit.CleanerML.list_cleanerml_files')
     @mock.patch('bleachbit.RecognizeCleanerML.cleaner_change_dialog')
-    def _setup_new_cleaner(self, gui, mock_cleaner_change_dialog, mock_list_cleanerml_files):
-        def _create_cleaner_file_in_directory(dirname):
+    def _setup_new_cleaner(self, gui, dirname, cleaner_id, option_id, mock_cleaner_change_dialog):#, mock_list_cleanerml_files):
+        def _create_cleaner_file_in_directory(cleaner_id, option_id, dirname):
             cleaner_content = ('<?xml version="1.0" encoding="UTF-8"?>'
-                               '<cleaner id="{}">'
-                               '<label>Test run_operations</label>'
-                               '<option id="{}">'
-                               '<label>Test1</label>'
+                               '<cleaner id="{0}">'
+                               '<label>{0}_label</label>'
+                               '<option id="{1}">'
+                               '<label>{1}_label</label>'
                                '<description>Delete files in a test directory</description>'
-                               '<action command="delete" search="walk.all" path="{}"/>'
+                               '<action command="delete" search="walk.all" path="{2}"/>'
                                '</option>'
-                               '</cleaner>'.format(self._NEW_CLEANER_ID, self._NEW_OPTION_ID, dirname))
+                               '</cleaner>'.format(cleaner_id, option_id, dirname))
             cleaner_filename = os.path.join(
-                dirname, 'test_run_operations_cleaner.xml')
+                dirname, 'test_gui_cleaner_{}.xml'.format(cleaner_id))
             self.write_file(cleaner_filename, cleaner_content, 'w')
             return cleaner_filename
 
-        def _set_mocks_return_values(cleaner_filename, mock_cleaner_change_dialog, mock_list_cleanerml_files):
-            mock_list_cleanerml_files.return_value = [cleaner_filename]
+        def _set_mocks_return_values(cleaner_filename, mock_cleaner_change_dialog):#, mock_list_cleanerml_files):
+            # mock_list_cleanerml_files.return_value = [cleaner_filename]
             mock_cleaner_change_dialog.return_value = None
 
         def _load_new_cleaner_in_gui(gui):
-            # to load the new test cleaner with id 'test_run_operations'
+            # to load the new test cleaner
             gui.cb_refresh_operations()
             self.refresh_gui()
 
-        dirname = self.mkdtemp(prefix='bleachbit-test-run_operations')
-        cleaner_filename = _create_cleaner_file_in_directory(dirname)
+        cleaner_filename = _create_cleaner_file_in_directory(cleaner_id, option_id, dirname)
         self.assertExists(cleaner_filename)
         _set_mocks_return_values(
-            cleaner_filename, mock_cleaner_change_dialog, mock_list_cleanerml_files)
+            cleaner_filename, mock_cleaner_change_dialog)#, mock_list_cleanerml_files)
         _load_new_cleaner_in_gui(gui)
         file_to_clean = self.mkstemp(prefix="somefile", dir=dirname)
         self.assertExists(file_to_clean)
@@ -270,31 +268,37 @@ class GUITestCase(common.BleachbitTestCase):
 
     def test_run_operations(self):
         gui = self.app._window
-        file_to_clean = self._setup_new_cleaner(gui)
-        self._put_checkmark_on_cleaner(
-            gui, self._NEW_CLEANER_ID, self._NEW_OPTION_ID)
+        cleaner_id = 'test_run_operations'
+        option_id = 'test_run_operations_option'
+        dirname = self.mkdtemp(prefix='bleachbit-test-run_operations')
+        with mock.patch('bleachbit.system_cleaners_dir', dirname):
+            file_to_clean = self._setup_new_cleaner(gui, dirname, cleaner_id, option_id)
+            self._put_checkmark_on_cleaner(gui, cleaner_id, option_id)
 
-        with mock.patch('bleachbit.GUI.GUI._confirm_delete', return_value=True):
-            self.assertTrue(gui._confirm_delete(False, False))
-            # same as b = self.click_button(gui, _("Clean"))
-            gui.run_operations(None)
+            with mock.patch('bleachbit.GUI.GUI._confirm_delete', return_value=True):
+                self.assertTrue(gui._confirm_delete(False, False))
+                # same as b = self.click_button(gui, _("Clean"))
+                gui.run_operations(None)
 
-        self.refresh_gui()
-        self.assertNotExists(file_to_clean)
+            self.refresh_gui()
+            self.assertNotExists(file_to_clean)
 
     def test_cb_run_option(self):
         gui = self.app._window
-        file_to_clean = self._setup_new_cleaner(gui)
+        cleaner_id, option_id = 'test_cb_run_option', 'test_cb_run_option_suboption'
+        dirname = self.mkdtemp(prefix='bleachbit-test-cb_run_option')
+        with mock.patch('bleachbit.system_cleaners_dir', dirname):
+            file_to_clean = self._setup_new_cleaner(gui, dirname, cleaner_id, option_id)
 
-        for really_delete, assert_method in [(False, self.assertExists), (True, self.assertNotExists)]:
-            with mock.patch('bleachbit.GUI.GUI._confirm_delete', return_value=True):
-                self.assertTrue(gui._confirm_delete(False, False))
-                gui.cb_run_option(
-                    None, really_delete, self._NEW_CLEANER_ID, self._NEW_OPTION_ID
-                )  # activated from context menu
+            for really_delete, assert_method in [(False, self.assertExists), (True, self.assertNotExists)]:
+                with mock.patch('bleachbit.GUI.GUI._confirm_delete', return_value=True):
+                    self.assertTrue(gui._confirm_delete(False, False))
+                    gui.cb_run_option(
+                        None, really_delete, cleaner_id, option_id
+                    )  # activated from context menu
 
-            self.refresh_gui()
-            assert_method(file_to_clean)
+                self.refresh_gui()
+                assert_method(file_to_clean)
 
     def _get_checkmark_state_for_cleaner(self, gui, cleaner_id, option_id):
         # todo clean duplication with set_checkmark...
@@ -308,13 +312,92 @@ class GUITestCase(common.BleachbitTestCase):
         checkmark_state = model[it][1]
         return parent_check_mark_state, checkmark_state
 
-    def test_select_all_no_warning(self):
+    def test_select_all_deselect_all_based_on_clean_selection(self):
         gui = self.app._window
-        file_to_clean = self._setup_new_cleaner(gui)
-        gui._select_all_button.emit("pressed")
-        self.refresh_gui()
+        cleaner_id, option_id = 'test_select_all', 'test_select_all_option'
+        dirname = self.mkdtemp(prefix='test_select_all_deselect_all_based_on_clean_selection')
+        with mock.patch('bleachbit.system_cleaners_dir', dirname):
+            self._setup_new_cleaner(gui,dirname, cleaner_id, option_id)
+            gui._select_all_button.emit("pressed")
+            self.refresh_gui()
+            
+            parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(
+                gui, cleaner_id, option_id)
+            self.assertTrue(parent_check_mark_state)
+            self.assertTrue(checkmark_state)
+            
+            gui._deselect_all_button.emit("pressed")
+            parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(
+                gui, cleaner_id, option_id)
+            self.assertFalse(parent_check_mark_state)
+            self.assertFalse(checkmark_state)
+    
+    def test_select_all_based_on_existing_selection(self):
         gui = self.app._window
-        parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(
-            gui, self._NEW_CLEANER_ID, self._NEW_OPTION_ID)
-        self.assertTrue(parent_check_mark_state)
-        self.assertTrue(checkmark_state)
+        cleaner_id, option_id = 'test_select_all', 'test_select_all_option'
+        secon_cleaner_template = '{}_2'
+        cleaner_id_2, option_id_2 = secon_cleaner_template.format(cleaner_id), secon_cleaner_template.format(option_id)
+        dirname = self.mkdtemp(prefix='test_select_all_based_on_existing_selection')
+        with mock.patch('bleachbit.system_cleaners_dir', dirname):
+            from bleachbit.Cleaner import backends
+            self._setup_new_cleaner(gui, dirname, cleaner_id, option_id)
+            self._setup_new_cleaner(gui, dirname, cleaner_id_2, option_id_2)
+            
+            self._put_checkmark_on_cleaner(gui, cleaner_id, option_id)
+            parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(
+                gui, cleaner_id, option_id)
+            self.assertTrue(parent_check_mark_state)
+            self.assertTrue(checkmark_state)
+            
+            parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(
+                gui, cleaner_id_2, option_id_2)
+            self.assertFalse(parent_check_mark_state)
+            self.assertFalse(checkmark_state)
+            
+            gui._select_all_button.emit("pressed")
+            self.refresh_gui()
+            
+            parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(
+                gui, cleaner_id, option_id)
+            self.assertTrue(parent_check_mark_state)
+            self.assertTrue(checkmark_state)
+            
+            parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(
+                gui, cleaner_id_2, option_id_2)
+            self.assertTrue(parent_check_mark_state)
+            self.assertTrue(checkmark_state)
+       
+    def test_deselect_all_based_on_existing_selection(self):    
+        gui = self.app._window
+        cleaner_id, option_id = 'test_select_all', 'test_select_all_option'
+        secon_cleaner_template = '{}_2'
+        cleaner_id_2, option_id_2 = secon_cleaner_template.format(cleaner_id), secon_cleaner_template.format(option_id)
+        dirname = self.mkdtemp(prefix='test_select_all_based_on_existing_selection')
+        with mock.patch('bleachbit.system_cleaners_dir', dirname):
+            from bleachbit.Cleaner import backends
+            self._setup_new_cleaner(gui, dirname, cleaner_id, option_id)
+            self._setup_new_cleaner(gui, dirname, cleaner_id_2, option_id_2)
+            
+            self._put_checkmark_on_cleaner(gui, cleaner_id, option_id)
+            parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(
+                gui, cleaner_id, option_id)
+            self.assertTrue(parent_check_mark_state)
+            self.assertTrue(checkmark_state)
+            
+            parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(
+                gui, cleaner_id_2, option_id_2)
+            self.assertFalse(parent_check_mark_state)
+            self.assertFalse(checkmark_state)
+            
+            gui._deselect_all_button.emit("pressed")
+            self.refresh_gui()
+            
+            parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(
+                gui, cleaner_id, option_id)
+            self.assertFalse(parent_check_mark_state)
+            self.assertFalse(checkmark_state)
+            
+            parent_check_mark_state, checkmark_state = self._get_checkmark_state_for_cleaner(
+                gui, cleaner_id_2, option_id_2)
+            self.assertFalse(parent_check_mark_state)
+            self.assertFalse(checkmark_state)

--- a/tests/TestGUI.py
+++ b/tests/TestGUI.py
@@ -325,33 +325,38 @@ class GUITestCase(common.BleachbitTestCase):
             
             self._assert_checkmark_active(self._cleaner_id, self._option_id, False)
 
-    def test_select_all_deselect_all_based_on_clean_selection(self):
+    @mock.patch('bleachbit.Cleaner.System.get_options')
+    def test_select_all_deselect_all_based_on_clean_selection(self, mock_system_get_options):
+        mock_system_get_options.return_value = [] # do not show System cleaner in the GUI
         with mock.patch('bleachbit.system_cleaners_dir', self._dirname):
             self._setup_new_cleaner(self._dirname, self._cleaner_id, self._option_id)
             self._gui._select_all_button.emit("pressed")
             self.refresh_gui()
-            
+
             self._assert_checkmark_active(self._cleaner_id, self._option_id, True)
-            
+
             self._gui._deselect_all_button.emit("pressed")
-            
+
             self._assert_checkmark_active(self._cleaner_id, self._option_id, False)
-    
-    def test_select_all_based_on_existing_selection(self):
+
+    @mock.patch('bleachbit.Cleaner.System.get_options')
+    def test_select_all_based_on_existing_selection(self, mock_system_get_options):
+        mock_system_get_options.return_value = [] # do not show System cleaner in the GUI
         with mock.patch('bleachbit.system_cleaners_dir', self._dirname):
+            from bleachbit.Cleaner import backends
             self._setup_new_cleaner(self._dirname, self._cleaner_id, self._option_id)
             self._setup_new_cleaner(self._dirname, self._cleaner_id_2, self._option_id_2)
-            
+
             self._put_checkmark_on_cleaner(self._cleaner_id, self._option_id)
             self._assert_checkmark_active(self._cleaner_id, self._option_id, True)
             self._assert_checkmark_active(self._cleaner_id_2, self._option_id_2, False)
-            
+
             self._gui._select_all_button.emit("pressed")
             self.refresh_gui()
             self._assert_checkmark_active(self._cleaner_id, self._option_id, True)
             self._assert_checkmark_active(self._cleaner_id_2, self._option_id_2, True)
-       
-    def test_deselect_all_based_on_existing_selection(self):    
+
+    def test_deselect_all_based_on_existing_selection(self):
         with mock.patch('bleachbit.system_cleaners_dir', self._dirname):
             self._setup_new_cleaner(self._dirname, self._cleaner_id, self._option_id)
             self._setup_new_cleaner(self._dirname, self._cleaner_id_2, self._option_id_2)


### PR DESCRIPTION
I would like to show this initial implementation and collect feedback. The main question is about the warnings. For now I accumulate them per cleaner / section and show the accumulated ones, one by one. For example if there are two or more messages for given section (e.g. Firefox) only one is displayed, and so on for the rest of the sections. I have another suggestion. We can re-name the button to 'Force select all' and show a single message that describes what are the caveats in principle. Or we can have a setting in the preference dialog which toggles warnings on 'Select all'. Initial suggestion "An improvement would be to show all the warnings simultaneously. There are check boxes for each option with all options enabled by default." is very good but still I am not sure that additional set of checkboxes in the warning dialog would be effective enough. 