### PR TITLE
fix: missing developer name in the metainfo file

### DIFF
--- a/org.bleachbit.BleachBit.metainfo.xml
+++ b/org.bleachbit.BleachBit.metainfo.xml
@@ -4,6 +4,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0</project_license>
   <name>BleachBit</name>
+  <developer id="org.bleachbit">
+    <name>BleachBit Developers</name>
+  </developer>
   <!-- Empty content_rating element indicates BleachBit is free of potentially offensive content (like most software tools). -->
   <content_rating type="oars-1.0" />
   <launchable type="desktop-id">org.bleachbit.BleachBit.desktop</launchable>


### PR DESCRIPTION
The developer name field (https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer) is required in Flathub. The absence of it prevents updates.