### PR TITLE
Improve portability around hardcoded /usr/share in bleachbit.py; respect destdir and prefix in po/Makefile; correct shebangs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ install:
 	$(INSTALL_DATA) bleachbit.png $(DESTDIR)$(datadir)/pixmaps/
 
 	# translations
-	make -C po install DESTDIR=$(DESTDIR)
+	make -C po install prefix=$(prefix) datadir=$(datadir) DESTDIR=$(DESTDIR)
 
 	# PolicyKit
 	mkdir -p $(DESTDIR)$(datadir)/polkit-1/actions

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ install:
 	mkdir -p $(DESTDIR)$(bindir)
 	$(INSTALL_DATA) bleachbit.py $(DESTDIR)$(bindir)/bleachbit
 	chmod 0755 $(DESTDIR)$(bindir)/bleachbit
+	# Update the hardcoded /usr/share in bleachbit.py to match the datadir set by the user.
+	sed -i 's|/usr/share|$(datadir)|g' $(DESTDIR)$(bindir)/bleachbit
 
 	# application launcher
 	mkdir -p $(DESTDIR)$(datadir)/applications

--- a/bleachbit.py
+++ b/bleachbit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim: ts=4:sw=4:expandtab
 
 # BleachBit

--- a/bleachbit/CLI.py
+++ b/bleachbit/CLI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim: ts=4:sw=4:expandtab
 
 # BleachBit

--- a/bleachbit/GUI.py
+++ b/bleachbit/GUI.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim: ts=4:sw=4:expandtab
 
 # BleachBit

--- a/po/Makefile
+++ b/po/Makefile
@@ -67,10 +67,10 @@ local: $(MOFILES)
 	@echo "Now you can run cd ..; python3 bleachbit/GUI.py"
 
 install: $(MOFILES)
-	echo "* Installing in $(DESTDIR)/usr/share/locale"
+	echo "* Installing in $(DESTDIR)$(datadir)/locale"
 	for MO in $(MOFILES); do \
 		lang=`basename $$MO .mo`; \
-		DST=$(DESTDIR)/usr/share/locale/$$lang/LC_MESSAGES/; \
+		DST=$(DESTDIR)$(datadir)/locale/$$lang/LC_MESSAGES/; \
 		mkdir -p $$DST; \
 		cp $$MO $$DST/bleachbit.mo; \
 done

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # vim: ts=4:sw=4:expandtab
 
 # BleachBit

--- a/tests/TestAll.py
+++ b/tests/TestAll.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # vim: ts=4:sw=4:expandtab
 
 # BleachBit

--- a/tests/TestCLI.py
+++ b/tests/TestCLI.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # vim: ts=4:sw=4:expandtab
 
 # BleachBit

--- a/tests/TestNsisUtilities.py
+++ b/tests/TestNsisUtilities.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim: ts=4:sw=4:expandtab
 
 # BleachBit

--- a/tests/TestWipe.py
+++ b/tests/TestWipe.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # vim: ts=4:sw=4:expandtab
 
 # BleachBit

--- a/windows/NsisUtilities.py
+++ b/windows/NsisUtilities.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim: ts=4:sw=4:expandtab
 
 # BleachBit


### PR DESCRIPTION
This will correct the hardcoded `/usr/share` path in the installed bleachbit.py to match the `/usr/local` or other prefix passed to the makefile. If the prefix is `/usr`, things will behave as before.

Also, have pass the values of prefix and datadir to po/Makefile and have it respect them.

Additionally, correct the shebangs to not be hardcoded to `/usr/bin`. I'm not sure what happened with #972, as the issues that were brought up there after 4580240f7e86cd0732c89d5ab7dd77c4fc9b6864 seem to have been ignored and the issue closed regardless. I have reverted that change, as well as fixed a few other broken shebangs-- I have not added shebangs to files that were missing them in the first place, only those that had them removed.