### PR TITLE
Copy To/Move To Dolphin history

### DIFF
--- a/cleaners/kde.xml
+++ b/cleaners/kde.xml
@@ -44,5 +44,7 @@
     <action command="delete" search="glob" path="~/.kde/share/apps/RecentDocuments/*.desktop"/>
     <action command="delete" search="glob" path="~/.kde4/share/apps/RecentDocuments/*.desktop"/>
     <action command="delete" search="glob" path="~/.local/share/RecentDocuments/*.desktop"/>
+    <action command="ini" search="file" path="~/.config/dolphinrc" section="kuick-copy" parameter="Paths[$e]"/>
+    <action command="ini" search="file" path="~/.config/dolphinrc" section="kuick-move" parameter="Paths[$e]"/>
   </option>
 </cleaner>


### PR DESCRIPTION
Clears recent locations where files have been copied or moved to (menu triggered when right clicking on a file in Dolphin).

Needs a fix since "ini" command parser expects to not have duplicates, so before cleaning up it is throwing: 

`configparser.DuplicateOptionError: While reading from '/home/myuser/.config/dolphinrc' [line 30]: option '1920x1080 screen' in section 'KPropertiesDialog' already exists`

