### PR TITLE
fix: safely delete a file

### DIFF
--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -51,6 +51,8 @@ if 'nt' == os.name:
     os_path_islink = os.path.islink
     os.path.islink = lambda path: os_path_islink(
         path) or bleachbit.Windows.is_junction(path)
+    os_remove = os.remove
+    os.remove = lambda pathname: bleachbit.Windows.delete_file(pathname, func_remove=os_remove)
 
 if 'posix' == os.name:
     from bleachbit.General import WindowsError

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -143,6 +143,23 @@ def csidl_to_environ(varname, csidl):
     # there is exception handling in set_environ()
     set_environ(varname, sppath)
 
+def delete_file(pathname, func_remove=None):
+    """Safely delete a file"""
+    handle = win32file.CreateFile(
+        os.path.dirname(os.path.abspath(pathname)),
+        win32file.GENERIC_READ,
+        win32file.FILE_SHARE_READ,
+        None,
+        win32file.OPEN_EXISTING,
+        win32con.FILE_FLAG_BACKUP_SEMANTICS,
+        None
+    )
+    if handle != win32file.INVALID_HANDLE_VALUE:
+        if func_remove:
+            func_remove(pathname)
+        else:
+            win32file.DeleteFile(pathname)
+        win32file.CloseHandle(handle)
 
 def delete_locked_file(pathname):
     """Delete a file that is currently in use"""


### PR DESCRIPTION
Open the parent directory of the file before removing it to avoid an attacker changing the parent directory to a junction.