### PR TITLE
fix: incorrect metainfo <description> format

### DIFF
--- a/org.bleachbit.BleachBit.metainfo.xml
+++ b/org.bleachbit.BleachBit.metainfo.xml
@@ -14,7 +14,7 @@
   <launchable type="desktop-id">org.bleachbit.BleachBit.desktop</launchable>
   <summary>Free space and maintain privacy</summary>
   <description>
-     BleachBit frees disk space and maintains privacy by quickly removing unnecessary files such as cache, cookies, browser history, temporary files, and system logs. It can also shred files  and clean free disk space to prevent data recovery.
+     <p>BleachBit frees disk space and maintains privacy by quickly removing unnecessary files such as cache, cookies, browser history, temporary files, and system logs. It can also shred files  and clean free disk space to prevent data recovery.</p>
   </description>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
Instead of being in plain text, the `<description>` must be in a markup language like HTML: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description

It causes failure in https://github.com/flathub-infra/vorarbeiter/actions/runs/17012726789/job/48230930367. Blocks https://github.com/flathub/org.bleachbit.BleachBit/pull/32

## How to verify

```
flatpak run --command=flatpak-builder-lint org.flatpak.Builder  appstream org.bleachbit.BleachBit.metainfo.xml
# or
appstreamcli validate org.bleachbit.BleachBit.metainfo.xml
```