### PR TITLE
Add warning for update uninstaller option in System cleaner

### DIFF
--- a/bleachbit/Cleaner.py
+++ b/bleachbit/Cleaner.py
@@ -317,6 +317,7 @@ class System(Cleaner):
             # the uninstallers for software updates.
             self.add_option('updates', _('Update uninstallers'), _(
                 'Delete uninstallers for Microsoft updates including hotfixes, service packs, and Internet Explorer updates'))
+            self.set_warning('updates', _('This option may prevent uninstalling some updates.'))
 
         #
         # options for GTK+


### PR DESCRIPTION
It does what it says on the tin -- basically, it alerts the user that it's about to delete files in the C:\Windows.old folder which will prevent uninstallation of certain Windows updates as well as rolling back to previous Windows builds.