### PR TITLE
Fixed help_contents_url for redirect

### DIFF
--- a/bleachbit/__init__.py
+++ b/bleachbit/__init__.py
@@ -196,7 +196,7 @@ elif sys.platform.startswith("openbsd") or sys.platform.startswith("freebsd"):
 # URLs
 #
 base_url = "https://update.bleachbit.org"
-help_contents_url = https://www.bleachbit.org/help"
+help_contents_url = "https://www.bleachbit.org/help"
 update_check_url = "%s/update/%s" % (base_url, APP_VERSION)
 
 # set up environment variables


### PR DESCRIPTION
Changed Help URL from non-functional version-dependent link (https://update.bleachbit.org/help/5.0.2) to basic correct URL (https://www.bleachbit.org/help)

PR for https://github.com/bleachbit/bleachbit/issues/1990