### PR TITLE
Fix GUI deadlock when loading malformed XML cleaners (#2034)

### DIFF
--- a/bleachbit/CleanerML.py
+++ b/bleachbit/CleanerML.py
@@ -152,7 +152,7 @@ class CleanerML:
         try:
             tree = xml.etree.ElementTree.parse(pathname)
             root_element = tree.getroot()
-        except (xml.etree.ElementTree.ParseError, xml.parsers.expat.ExpatError) as e:
+        except Exception as e:
             logger.error(
                 "Error parsing CleanerML file %s with error %s", pathname, e)
             return
@@ -394,6 +394,9 @@ def load_cleaners(cb_progress=lambda x: None):
             # TRANSLATORS: Error message printed to the log.
             # %s expands to the path of the XML cleaner file
             logger.exception(_("Error reading cleaner: %s"), pathname)
+            files_done += 1
+            cb_progress(1.0 * files_done / total_files)
+            yield True
             continue
         cleaner = xmlcleaner.get_cleaner()
         if cleaner.is_usable():

--- a/tests/TestCleanerML.py
+++ b/tests/TestCleanerML.py
@@ -108,6 +108,26 @@ class CleanerMLTestCase(common.BleachbitTestCase):
         shutil.rmtree(bleachbit.personal_cleaners_dir)
         bleachbit.personal_cleaners_dir = pcd
 
+    def test_load_cleaners_invalid_utf8(self):
+        """Unit test for load_cleaners() with invalid UTF-8 encoding"""
+        pcd = bleachbit.personal_cleaners_dir
+        bleachbit.personal_cleaners_dir = self.mkdtemp(
+            prefix='bleachbit-cleanerml-utf8')
+        self.write_file(os.path.join(bleachbit.personal_cleaners_dir, 'broken_encoding.xml'),
+                        contents=b'<cleaner id="poison">\n\xff\xfe\xfd Broken\n')
+        list(load_cleaners())
+        shutil.rmtree(bleachbit.personal_cleaners_dir)
+        bleachbit.personal_cleaners_dir = pcd
+
+    def test_CleanerML_invalid_utf8(self):
+        """Unit test for CleanerML() with invalid UTF-8 encoding"""
+        fn = os.path.join(self.mkdtemp(prefix='bleachbit-cleanerml-utf8'),
+                          'broken.xml')
+        self.write_file(fn, contents=b'<cleaner id="poison">\n\xff\xfe\xfd\n')
+        xmlcleaner = CleanerML(fn)
+        self.assertIsInstance(xmlcleaner, CleanerML)
+        self.assertFalse(xmlcleaner.cleaner.is_usable())
+
     def test_os_match(self):
         """Unit test for os_match"""
         xmlcleaner = CleanerML("doc/example_cleaner.xml")


### PR DESCRIPTION
# Pull Request: Fix GUI deadlock when loading malformed XML cleaners (#2034)

**Context:**
Currently, if a user has a malformed XML file (e.g., containing invalid UTF-8 byte sequences) in their `~/.config/bleachbit/cleaners/` directory, BleachBit fails to start properly. The main GUI window opens but remains completely blank and unresponsive. This acts as a denial-of-service vulnerability against the application: a single anomalous cleaner file entirely prevents the user from accessing their privacy tools. This PR resolves [Issue #2034](https://github.com/bleachbit/bleachbit/issues/2034).

**The Approach:**
The root cause existed at two interconnected levels within `CleanerML.py`. I have implemented targeted exception handling and generator recovery to fix both.

**1. Broadening Exception Handling in `CleanerML.__init__()`**
Previously, the constructor only caught XML-specific errors (`ParseError` and `ExpatError`). I broadened this block to catch a generic `Exception`. This ensures that native OS and encoding errors from `ElementTree.parse()` (such as `UnicodeDecodeError` or `FileNotFoundError`) are gracefully caught, logged, and result in a safe, unusable cleaner object rather than corrupting the call stack.

```python
# bleachbit/CleanerML.py
try:
    tree = xml.etree.ElementTree.parse(pathname)
    root_element = tree.getroot()
except Exception as e: # <--- Changed from: except (xml.etree.ElementTree.ParseError, xml.parsers.expat.ExpatError)
    logger.error("Error parsing CleanerML file %s with error %s", pathname, e)
    return
```

**2. Generator Recovery in `CleanerML.load_cleaners()`**
When an exception was caught during cleaner instantiation, the loop `continue`d but skipped the necessary GTK progress updates. I added the increment and `yield True` steps inside the error handler so that GTK's idle loop (`GLib.idle_add`) remains responsive and the `register_cleaners` generator successfully yields control back to the UI, preventing the deadlock.

```python
# bleachbit/CleanerML.py
try:
    xmlcleaner = CleanerML(pathname)
except Exception:
    logger.exception(_("Error reading cleaner: %s"), pathname)
    files_done += 1                               # <--- Added
    cb_progress(1.0 * files_done / total_files)   # <--- Added
    yield True                                    # <--- Added
    continue
```

**3. Test Coverage (`TestCleanerML.py`)**
I added two new unit tests to specifically simulate the `\xff\xfe\xfd` invalid UTF-8 byte sequences reported in the issue, ensuring both the constructor and the loader pipeline handle them gracefully without crashing.

```python
def test_load_cleaners_invalid_utf8(self):
    """Unit test for load_cleaners() with invalid UTF-8 encoding"""
    pcd = bleachbit.personal_cleaners_dir
    bleachbit.personal_cleaners_dir = self.mkdtemp(prefix='bleachbit-cleanerml-utf8')
    self.write_file(os.path.join(bleachbit.personal_cleaners_dir, 'broken_encoding.xml'),
                    contents=b'<cleaner id="poison">\n\xff\xfe\xfd Broken\n')
    list(load_cleaners())
    shutil.rmtree(bleachbit.personal_cleaners_dir)
    bleachbit.personal_cleaners_dir = pcd
```

**Impact:**
This makes BleachBit significantly more resilient. Corrupted, maliciously crafted, or strictly invalid personal cleaner files will now simply throw a logged error in the console, while the rest of the application loads and functions normally. All unit tests (`python -m pytest tests/TestCleanerML.py`) pass successfully.