### PR TITLE
Improve Claude cleaner: add running detection, expand cache/session coverage

### DIFF
--- a/cleaners/claude.xml
+++ b/cleaners/claude.xml
@@ -9,6 +9,8 @@ later.  See the COPYING file in the top-level directory.
 <cleaner id="claude">
   <label>Claude</label>
   <description translators="Label for Claude coding assistant">AI assistant</description>
+  <running type="exe" os="windows">Claude.exe</running>
+  <running type="exe" os="linux">claude</running>
   <option id="backup">
     <label>Backup files</label>
     <description>Delete the backup files</description>
@@ -18,18 +20,32 @@ later.  See the COPYING file in the top-level directory.
     <label>Cache</label>
     <description>Delete the cache</description>
     <action command="delete" search="walk.all" path="~/.claude/cache/"/>
+    <action command="delete" search="walk.all" path="~/.claude/plugins/cache/"/>
+  </option>
+  <option id="file_history">
+    <label>File history</label>
+    <description>Delete the file history used for /restore</description>
+    <action command="delete" search="walk.all" path="~/.claude/file-history/"/>
   </option>
   <option id="logs">
     <label>Logs</label>
     <description>Delete the logs</description>
     <action command="delete" search="walk.files" path="~/.claude/debug/"/>
     <action command="delete" search="walk.files" path="~/.claude/logs/"/>
+    <action command="delete" search="file" path="~/.claude/" regex="\.log$"/>
   </option>
   <option id="session">
     <label>Session</label>
     <description translators="Description for deleting Claude Code sessions">Delete the conversation history</description>
     <warning>You would lose resume, continue, and rewind for past sessions</warning>
-    <action command="delete" search="walk.files" path="~/.claude/projects/"/>
+    <action command="delete" search="walk.all" path="~/.claude/projects/"/>
+    <action command="delete" search="walk.all" path="~/.claude/sessions/"/>
+    <action command="delete" search="walk.all" path="~/.claude/session-env/"/>
+  </option>
+  <option id="shell_snapshots">
+    <label>Shell snapshots</label>
+    <description>Delete saved shell output snapshots</description>
+    <action command="delete" search="walk.all" path="~/.claude/shell-snapshots/"/>
   </option>
   <option id="tmp">
     <label>Temporary files</label>


### PR DESCRIPTION
## Summary

This improves the Claude cleaner (`cleaners/claude.xml`) in several ways:

### Fixes
- **Cache**: Added `~/.claude/plugins/cache/` path — the original only checked `~/.claude/cache/` which doesn't exist on current Claude Code installations. Plugin cache is where actual cached data lives.
- **Session**: Expanded to cover `~/.claude/sessions/` and `~/.claude/session-env/` in addition to `projects/`. Also changed from `walk.files` to `walk.all` so subdirectories (e.g., `subagents/`, `tool-results/`) get cleaned too.

### Additions
- **Running detection**: Added `<running>` elements for `Claude.exe` (Windows) and `claude` (Linux) to prevent cleaning while Claude is running.
- **New options**: `file_history` (clean file history from `/restore`), `shell_snapshots` (clean saved shell output)
- **Logs**: Added `*.log` file detection in the root `.claude/` directory

### Verification

Tested on Windows 11 with both Claude Code CLI and Claude Desktop:
- Preview correctly identifies all files across all 7 options
- Clean is blocked when Claude.exe is running ("Claude cannot be cleaned because it is currently running")
- Paths use `~/.claude/` which resolves correctly on both Windows and Linux via `os.path.expanduser`

🤖 Generated with [Claude Code](https://claude.com/claude-code)