### PR TITLE
Add custom folder contents cleanup option

### DIFF
--- a/bleachbit/Cleaner.py
+++ b/bleachbit/Cleaner.py
@@ -358,9 +358,13 @@ class System(Cleaner):
                         for path in children_in_directory(c_path, True):
                             yield Command.Delete(path)
                         yield Command.Delete(c_path)
+                elif 'folder_contents' == c_type:
+                    if os.path.lexists(c_path):
+                        for path in children_in_directory(c_path, True):
+                            yield Command.Delete(path)
                 else:
                     raise RuntimeError(
-                        f'custom folder has invalid type {c_type}')
+                        f'custom path has invalid type {c_type}')
 
         # menu
         menu_dirs = ['~/.local/share/applications',

--- a/bleachbit/GuiPreferences.py
+++ b/bleachbit/GuiPreferences.py
@@ -38,7 +38,7 @@ from bleachbit.GuiUtil import (detect_dark_background, flush_gtk_events,
                                should_show_dark_mode_warning)
 from bleachbit.Language import get_active_language_code, get_supported_language_code_name_dict, setup_translation
 from bleachbit.Language import get_text as _, pget_text as _p
-from bleachbit.Options import options
+from bleachbit.Options import CUSTOM_PATH_TYPES, options
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +58,21 @@ EXPERT_MODE_MSG = _('Expert mode')
 # TRANSLATORS: Notice shown in an infobar after changing a preference
 # that requires starting the application to be effective.
 RESTART_APP_MSG = _("Restart BleachBit for full effect.")
+
+
+def _path_type_label(path_type):
+    """Return the user-facing label for a stored path type."""
+    if path_type == 'file':
+        # TRANSLATORS: Noun used as a column value in the preferences dialog.
+        return _('File')
+    if path_type == 'folder':
+        # TRANSLATORS: Noun used as a column value in the preferences dialog.
+        return _('Folder')
+    if path_type == 'folder_contents':
+        # TRANSLATORS: Noun phrase used as a column value in the preferences
+        # dialog. This means the contents of a folder, but not the folder itself.
+        return _('Folder contents')
+    raise RuntimeError("Invalid type code: '%s'" % path_type)
 
 
 class PreferencesDialog:
@@ -823,11 +838,10 @@ class PreferencesDialog:
             if not self._check_protected_path(pathname):
                 return
 
-        # TRANSLATORS: Noun used as a column header in the preferences dialog.
-        type_str_file = _('File')
-        # TRANSLATORS: Noun used as a column header in the preferences dialog.
-        type_str_folder = _('Folder')
-        type_str = type_str_file if path_type == 'file' else type_str_folder
+        if path_type not in CUSTOM_PATH_TYPES:
+            raise RuntimeError("Invalid type code: '%s'" % path_type)
+
+        type_str = _path_type_label(path_type)
         display_path = pathname.encode('utf-8', errors='replace').decode('utf-8')
         liststore.append([type_str, display_path])
         pathnames.append([path_type, pathname])
@@ -877,13 +891,7 @@ class PreferencesDialog:
         liststore = Gtk.ListStore(str, str)
         for paths in pathnames:
             type_code = paths[0]
-            type_str = None
-            if type_code == 'file':
-                type_str = _('File')
-            elif type_code == 'folder':
-                type_str = _('Folder')
-            else:
-                raise RuntimeError("Invalid type code: '%s'" % type_code)
+            type_str = _path_type_label(type_code)
             path = paths[1]
             display_path = path.encode('utf-8', errors='replace').decode('utf-8')
             liststore.append([type_str, display_path])
@@ -989,6 +997,16 @@ class PreferencesDialog:
                 self._add_path(pathname, 'folder', page_type,
                                liststore, pathnames)
 
+        def add_folder_contents_cb(button):
+            """Callback for adding the contents of a folder"""
+            # TRANSLATORS: Title of a folder chooser dialog.
+            title = _("Choose a folder")
+            pathname = GuiBasic.browse_folder(self.parent, title,
+                                              multiple=False, stock_button=Gtk.STOCK_ADD)
+            if pathname:
+                self._add_path(pathname, 'folder_contents', page_type,
+                               liststore, pathnames)
+
         def remove_path_cb(button):
             """Callback for removing a path"""
             self._remove_path(treeview, liststore, pathnames, page_type)
@@ -1001,6 +1019,12 @@ class PreferencesDialog:
             label=_p('button', 'Add folder'))
         button_add_folder.connect("clicked", add_folder_cb)
 
+        button_add_folder_contents = Gtk.Button.new_with_label(
+            # TRANSLATORS: Button label in the Custom preferences page. It adds
+            # a folder whose contents will be cleaned while the folder remains.
+            label=_p('button', 'Add folder contents'))
+        button_add_folder_contents.connect("clicked", add_folder_contents_cb)
+
         button_remove = Gtk.Button.new_with_label(label=_p('button', 'Remove'))
         button_remove.connect("clicked", remove_path_cb)
 
@@ -1008,6 +1032,8 @@ class PreferencesDialog:
         button_box.set_layout(Gtk.ButtonBoxStyle.START)
         button_box.pack_start(button_add_file, True, True, 0)
         button_box.pack_start(button_add_folder, True, True, 0)
+        if page_type == LOCATIONS_CUSTOM:
+            button_box.pack_start(button_add_folder_contents, True, True, 0)
         button_box.pack_start(button_remove, True, True, 0)
         vbox.pack_start(button_box, False, True, 0)
 

--- a/bleachbit/Options.py
+++ b/bleachbit/Options.py
@@ -42,6 +42,7 @@ from bleachbit.Language import get_text as _
 logger = logging.getLogger(__name__)
 
 FLUSH_DELAY_SECS = 15.0  # decimal seconds
+CUSTOM_PATH_TYPES = ('file', 'folder', 'folder_contents')
 
 OPTION_DEFAULTS = {
     'auto_hide': {'value': True},
@@ -341,7 +342,8 @@ class Options:
     def get_custom_paths(self):
         """Return list of custom paths
 
-        Returns a list of tuples (type, path) where type is 'file' or 'folder'
+        Returns a list of tuples (type, path) where type is one of
+        CUSTOM_PATH_TYPES.
         """
         return self.get_paths("custom/paths")
 
@@ -521,7 +523,7 @@ class Options:
         """Save the custom paths
 
         @param values: list of tuples containing (path_type, path)
-            where path_type is either 'file' or 'folder'
+            where path_type is one of CUSTOM_PATH_TYPES
         """
         section = "custom/paths"
         # Remove existing section first to clear old values
@@ -531,7 +533,7 @@ class Options:
         self.config.add_section(section)
         for counter, value in enumerate(values):
             path_type, path = value
-            assert path_type in ('file', 'folder')
+            assert path_type in CUSTOM_PATH_TYPES
             self.config.set(section, str(counter) + '_type', path_type)
             self.config.set(section, str(counter) + '_path', path)
         self.__schedule_flush()

--- a/tests/TestCleaner.py
+++ b/tests/TestCleaner.py
@@ -355,7 +355,7 @@ class CleanerTestCase(common.BleachbitTestCase):
         test_pathname = os.path.join(self.tempdir, 'foo')
 
         # Check that custom cleaner doesn't iterate non-existent object
-        for obj_type in ('folder', 'file'):
+        for obj_type in ('folder', 'folder_contents', 'file'):
             options.set_custom_paths([(obj_type, test_pathname)])
             for cmd in backends['system'].get_commands('custom'):
                 results = list(cmd.execute(really_delete=False))
@@ -382,6 +382,34 @@ class CleanerTestCase(common.BleachbitTestCase):
             results = list(cmd.execute(really_delete=False))
             self.assertEqual(len(results), 1)
             self.assertEqual(results[0]['path'], test_dirname)
+
+        # Check folder_contents deletes children but leaves the folder.
+        contents_dirname = os.path.join(self.tempdir, 'contents')
+        os.makedirs(contents_dirname)
+        contents_subdir = os.path.join(contents_dirname, 'subdir')
+        os.makedirs(contents_subdir)
+        contents_file = os.path.join(contents_dirname, 'file.txt')
+        contents_subfile = os.path.join(contents_subdir, 'subfile.txt')
+        common.touch_file(contents_file)
+        common.touch_file(contents_subfile)
+        options.set_custom_paths([('folder_contents', contents_dirname)])
+
+        commands = list(backends['system'].get_commands('custom'))
+        previewed = []
+        for cmd in commands:
+            previewed.extend(list(cmd.execute(really_delete=False)))
+        self.assertEqual(
+            {result['path'] for result in previewed},
+            {contents_file, contents_subfile, contents_subdir})
+        self.assertNotIn(contents_dirname, {result['path']
+                                            for result in previewed})
+
+        for cmd in commands:
+            list(cmd.execute(really_delete=True))
+        self.assertExists(contents_dirname)
+        self.assertNotExists(contents_file)
+        self.assertNotExists(contents_subfile)
+        self.assertNotExists(contents_subdir)
 
         # Restore the original settings.
         options.set_custom_paths(original_custom_paths)

--- a/tests/TestOptions.py
+++ b/tests/TestOptions.py
@@ -398,7 +398,7 @@ check_online_updates=True
                         o.set('shred', True)
                         o.set_list('list_test', ['a', 'b'])
                         o.set_whitelist_paths([('file', '/tmp/a')])
-                        o.set_custom_paths([('folder', '/tmp/b')])
+                        o.set_custom_paths([('folder_contents', '/tmp/b')])
                         o.set_language('zz', True)
                         o.set_tree('system', 'cache', True)
                         o.remember_warning_preference('warn_key')
@@ -423,7 +423,7 @@ check_online_updates=True
                     self.assertEqual(['a', 'b'], o3.get_list('list_test'))
                     self.assertEqual([('file', '/tmp/a')],
                                      o3.get_whitelist_paths())
-                    self.assertEqual([('folder', '/tmp/b')],
+                    self.assertEqual([('folder_contents', '/tmp/b')],
                                      o3.get_custom_paths())
                     self.assertTrue(o3.get_language('zz'))
                     self.assertTrue(o3.get_tree('system', 'cache'))


### PR DESCRIPTION
## Summary

Fixes #2073 by adding a new Custom cleanup option that deletes a folder’s contents while keeping the selected folder itself.

## Changes

- Add a new custom path type: `folder_contents`
- Add an **Add folder contents** button to the Custom preferences page
- Keep the existing **Add folder** behavior unchanged for backward compatibility
- Update custom cleaner logic so `folder_contents` deletes child files and subfolders, but not the parent folder
- Add tests for the new behavior and option persistence

## Why

Previously, adding a folder under Custom cleanup deleted both the folder’s contents and the folder itself. Some applications expect their folders to remain present and may fail or behave incorrectly if the parent folder is removed.

This change lets users clean only the contents of a folder when they need to preserve the folder path.

