### PR TITLE
Preserve Windows temp folder roots

### DIFF
--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -960,10 +960,29 @@ def whitelisted_posix(path, check_realpath=True, _followed_link=False):
     return False
 
 
+def _windows_preserved_temp_dir(path):
+    """Return whether this Windows path is a temp directory root to keep."""
+    path = extended_path_undo(os.path.normpath(path)).lower()
+    parts = path.split(os.sep)
+
+    if path == os.path.expandvars(r'%windir%\temp').lower():
+        return True
+
+    if len(parts) >= 3 and parts[-3:] == ['appdata', 'local', 'temp']:
+        return True
+
+    if len(parts) >= 2 and parts[-2:] == ['local settings', 'temp']:
+        return True
+
+    return False
+
+
 def whitelisted_windows(path):
     """Check whether this Windows path is whitelisted"""
     if not isinstance(path, str):
         raise TypeError(f"Expected str, got {type(path)}")
+    if _windows_preserved_temp_dir(path):
+        return True
     from bleachbit.Options import options
     for pathname in options.get_whitelist_paths():
         # Windows is case insensitive

--- a/tests/TestFileUtilities.py
+++ b/tests/TestFileUtilities.py
@@ -1628,6 +1628,25 @@ State=AAAA/wA...
         self.assertFalse(whitelisted('c:\\de\\strasse.txt'))
         self.assertFalse(whitelisted('c:\\de\\straSSe.txt'))
 
+    @common.skipUnlessWindows
+    def test_whitelisted_windows_temp_roots(self):
+        """Windows temp roots are preserved, but their contents are not."""
+        options.set_whitelist_paths([])
+        temp_roots = [
+            r'C:\Windows\Temp',
+            r'C:\WINDOWS\ServiceProfiles\MariaDB\AppData\Local\Temp',
+            r'C:\Windows\ServiceProfiles\LocalService\AppData\Local\Temp',
+            r'C:\Users\example\AppData\Local\Temp',
+            r'C:\Documents and Settings\example\Local Settings\Temp',
+        ]
+
+        for temp_root in temp_roots:
+            with self.subTest(temp_root=temp_root):
+                self.assert_is_whitelisted(temp_root)
+                self.assert_is_whitelisted(temp_root + '\\')
+                self.assertFalse(whitelisted(temp_root + r'\bleachbit.tmp'))
+                self.assertFalse(whitelisted(temp_root + r'\subdir'))
+
     @common.skipIfWindows
     def test_whitelisted_posix_symlink(self):
         """Symlink test for whitelisted_posix()"""


### PR DESCRIPTION
## Summary

Fixes #2123

This PR prevents BleachBit from deleting Windows temp directory roots while still allowing the contents inside those directories to be cleaned.

On Windows, deleting the temp folder itself can break services that expect their temp directory to exist. Issue #2123 reports this happening with MariaDB under:

`C:\WINDOWS\ServiceProfiles\MariaDB\AppData\Local\Temp`

After cleanup, MariaDB could not restart until the temp folder was recreated.

## Changes

- Add a Windows-only guard in `FileUtilities.whitelisted_windows()`.
- Preserve exact temp directory roots such as:
  - `C:\Windows\Temp`
  - `...\AppData\Local\Temp`
  - `...\Local Settings\Temp`
- Keep cleanup behavior for files and subdirectories inside those temp roots.
- Add regression tests confirming temp roots are protected but child paths are not.
