### PR TITLE
use POSIX locale order for validation

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -244,7 +244,7 @@ class BleachbitTestCase(unittest.TestCase):
         if lang_id in ('C', 'C.UTF-8', 'C.utf8', 'POSIX'):
             return
         self.assertTrue(len(lang_id) >= 2)
-        pattern = r'^[a-z]{2,3}([_-][A-Z][A-Za-z]{1,3})?(@\w+)?(\.[a-zA-Z][a-zA-Z0-9-]+)?$'
+        pattern = r'^[a-z]{2,3}([_-][A-Z][A-Za-z]{1,3})?(\.[a-zA-Z][a-zA-Z0-9-]+)?(@\w+)?$'
         self.assertTrue(re.match(pattern, lang_id),
                         f'Invalid language code format: {lang_id}')
 


### PR DESCRIPTION
`codeset` must come before `modifier`, fixing be_BY.utf8@latin for example

from setlocale(3):
 A  locale  name  is  typically  of  the form `language[_territory][.codeset][@modifier]`

See downstream bug:
https://bugs.gentoo.org/977413

Tested with this locale.gen :
```
en_US                   es_DO                   nhn_MX
fr_FR                   es_EC                   niu_NU
be_BY@latin             es_ES                   niu_NZ
aa_DJ                   es_GT                   nl_AW
aa_ER                   es_HN                   nl_BE
aa_ET                   es_MX                   nl_NL
af_ZA                   es_NI                   nn_NO
agr_PE                  es_PA                   nr_ZA
ak_GH                   es_PE                   nso_ZA
am_ET                   es_PR                   oc_FR
an_ES                   es_PY                   om_ET
anp_IN                  es_SV                   om_KE
ar_AE                   es_US                   or_IN
ar_BH                   es_UY                   os_RU
ar_DZ                   es_VE                   pa_IN
ar_EG                   et_EE                   pa_PK
ar_IN                   eu_ES                   pap_AW
ar_IQ                   fa_IR                   pap_CW
ar_JO                   ff_SN                   pl_PL
ar_KW                   fi_FI                   ps_AF
ar_LB                   fil_PH                  pt_BR
ar_LY                   fo_FO                   pt_PT
ar_MA                   fr_BE                   quz_PE
ar_OM                   fr_CA                   raj_IN
ar_QA                   fr_CH                   rif_MA
ar_SA                   fr_FR                   ro_RO
ar_SD                   fr_LU                   ru_RU
ar_SS                   fur_IT                  ru_UA
ar_SY                   fy_DE                   rw_RW
ar_TN                   fy_NL                   sa_IN
ar_YE                   ga_IE                   sah_RU
as_IN                   gbm_IN                  sat_IN
ast_ES                  gd_GB                   sc_IT
ayc_PE                  gez_ER                  scn_IT
az_AZ                   gez_ER@abegede          sd_IN
az_IR                   gez_ET                  sd_IN@devanagari
be_BY                   gez_ET@abegede          se_NO
be_BY@latin             gl_ES                   sgs_LT
bem_ZM                  gu_IN                   shn_MM
ber_DZ                  gv_GB                   shs_CA
ber_MA                  ha_NG                   si_LK
bg_BG                   hak_TW                  sid_ET
bhb_IN                  he_IL                   sk_SK
bho_IN                  hi_IN                   sl_SI
bho_NP                  hif_FJ                  sm_WS
bi_VU                   hne_IN                  so_DJ
bn_BD                   hr_HR                   so_ET
bn_IN                   hsb_DE                  so_KE
bo_CN                   ht_HT                   so_SO
bo_IN                   hu_HU                   sq_AL
br_FR                   hy_AM                   sq_MK
brx_IN                  ia_FR                   sr_ME
bs_BA                   id_ID                   sr_RS
byn_ER                  ig_NG                   sr_RS@latin
ca_AD                   ik_CA                   ss_ZA
ca_ES                   is_IS                   ssy_ER
ca_ES@valencia          it_CH                   st_ZA
ca_FR                   it_IT                   su_ID
ca_IT                   iu_CA                   sv_FI
ce_RU                   ja_JP                   sv_SE
chr_US                  ka_GE                   sw_KE
ckb_IQ                  kab_DZ                  sw_TZ
cmn_TW                  kk_KZ                   syr
crh_RU                  kl_GL                   szl_PL
crh_UA                  km_KH                   ta_IN
cs_CZ                   kn_IN                   ta_LK
csb_PL                  ko_KR                   tcy_IN
cv_RU                   kok_IN                  te_IN
cy_GB                   ks_IN                   tg_TJ
da_DK                   ks_IN@devanagari        th_TH
de_AT                   ku_TR                   the_NP
de_BE                   kv_RU                   ti_ER
de_CH                   kw_GB                   ti_ET
de_DE                   ky_KG                   tig_ER
de_IT                   lb_LU                   tk_TM
de_LI                   lg_UG                   tl_PH
de_LU                   li_BE                   tn_ZA
doi_IN                  li_NL                   to_TO
dsb_DE                  lij_IT                  tok
dv_MV                   ln_CD                   tpi_PG
dz_BT                   lo_LA                   tr_CY
el_CY                   lt_LT                   tr_TR
el_GR                   ltg_LV                  ts_ZA
en_AG                   lv_LV                   tt_RU
en_AU                   lzh_TW                  tt_RU@iqtelif
en_BW                   mag_IN                  ug_CN
en_CA                   mai_IN                  uk_UA
en_DK                   mai_NP                  unm_US
en_GB                   mdf_RU                  ur_IN
en_HK                   mfe_MU                  ur_PK
en_IE                   mg_MG                   uz_UZ
en_IL                   mhr_RU                  uz_UZ@cyrillic
en_IN                   mi_NZ                   ve_ZA
en_NG                   miq_NI                  vi_VN
en_NZ                   mjw_IN                  wa_BE
en_PH                   mk_MK                   wae_CH
en_SC                   ml_IN                   wal_ET
en_SE                   mn_MN                   wo_SN
en_SG                   mni_IN                  xh_ZA
en_US                   mnw_MM                  yi_US
en_ZA                   mr_IN                   yo_NG
en_ZM                   ms_MY                   yue_HK
en_ZW                   mt_MT                   yuw_PG
eo                      my_MM                   zgh_MA
es_AR                   nan_TW                  zh_CN
es_BO                   nan_TW@latin            zh_HK
es_CL                   nb_NO                   zh_SG
es_CO                   nds_DE                  zh_TW
es_CR                   nds_NL                  zu_ZA
es_CU                   ne_NP

```