### PR TITLE
Remove non-POSIX es_419

### DIFF
--- a/bleachbit/Language.py
+++ b/bleachbit/Language.py
@@ -84,7 +84,6 @@ native_locale_names = \
      'en_US': 'United States English',
      'eo': 'Esperanto',
      'es': 'Español',
-     'es_419': 'Latin American Spanish',
      'et': 'eesti',
      'eu': 'euskara',
      'fa': 'فارسی',


### PR DESCRIPTION
The locale es_419 was added as an ISO language code https://github.com/bleachbit/bleachbit/commit/618fc7e96b25d97a2411989e0372a0410abb7a6c, but it is not part of ISO‑3166 (419 != country) and therefore not a valid POSIX locale. If es_149 appears in /etc/locale.alias or /usr/share/locale, it will be rejected by assertIsLanguageCode because it's not a POSIX-locale.

Since this locale was not added for the purpose of testing a non‑POSIX value, remove it for now.

See downstream bug: https://bugs.gentoo.org/978295

TODO: test only locales in native_locale_names, not everything installed in /usr/share/locale