### PR TITLE
Handle interrupted Windows console output

### DIFF
--- a/bleachbit/CLI.py
+++ b/bleachbit/CLI.py
@@ -8,6 +8,7 @@
 Command line interface
 """
 
+import errno
 import logging
 import optparse
 import os
@@ -21,6 +22,8 @@ from bleachbit.Language import get_text as _
 from bleachbit.Log import set_root_log_level
 
 logger = logging.getLogger(__name__)
+
+_OUTPUT_CLOSED_ERRNOS = {errno.EINVAL, errno.EPIPE}
 
 
 def _write_update_output(value):
@@ -38,6 +41,7 @@ class CliCallback:
 
     def __init__(self, quiet=False):
         self.quiet = quiet
+        self._output_closed = False
 
     def append_text(self, msg, _tag=None):
         """Write text to the terminal"""
@@ -45,8 +49,17 @@ class CliCallback:
         # Surrogates (like \udcd6) can appear in filenames from the filesystem
         # and cause UnicodeEncodeError when GTK tries to insert them.
         msg = msg.encode('utf-8', errors='replace').decode('utf-8')
-        if not self.quiet:
+        if self.quiet or self._output_closed:
+            return
+        try:
             print(msg.strip('\n').encode(stdout_encoding, errors='replace').decode(stdout_encoding))
+        except BrokenPipeError:
+            self._output_closed = True
+        except OSError as e:
+            if e.errno in _OUTPUT_CLOSED_ERRNOS:
+                self._output_closed = True
+                return
+            raise
 
     def update_progress_bar(self, status):
         """Not used"""

--- a/tests/TestCLI.py
+++ b/tests/TestCLI.py
@@ -12,6 +12,7 @@ Test case for module CLI
 # standard imports
 import copy
 import datetime
+import errno
 import io
 import locale
 import os
@@ -294,6 +295,52 @@ class CLITestCase(common.BleachbitTestCase):
             cb.append_text(f"prefix{test_str}suffix\n")
             # Test tag parameter (ignored but should not crash)
             cb.append_text(test_str + "\n", _tag="test_tag")
+
+    def test_append_text_writes_stdout(self):
+        """Unit test for CliCallback.append_text() normal output"""
+        cb = CliCallback(quiet=False)
+        with patch('sys.stdout', new_callable=io.StringIO) as mock_stdout:
+            cb.append_text("hello\n")
+        self.assertEqual("hello\n", mock_stdout.getvalue())
+
+    def _assert_append_text_closes_output(self, exception):
+        """Verify append_text ignores interrupted stdout."""
+        class ClosedStdout:
+            def __init__(self, write_exception):
+                self.write_exception = write_exception
+                self.write_calls = 0
+
+            def write(self, _text):
+                self.write_calls += 1
+                raise self.write_exception
+
+            def flush(self):
+                return None
+
+        stdout = ClosedStdout(exception)
+        cb = CliCallback(quiet=False)
+        with patch('sys.stdout', stdout):
+            cb.append_text("hello\n")
+            cb.append_text("again\n")
+        self.assertEqual(1, stdout.write_calls)
+
+    def test_append_text_ignores_broken_pipe(self):
+        """Unit test for CliCallback.append_text() with a closed pipe"""
+        self._assert_append_text_closes_output(BrokenPipeError())
+
+    def test_append_text_ignores_windows_invalid_argument(self):
+        """Unit test for CliCallback.append_text() after more.com exits"""
+        self._assert_append_text_closes_output(
+            OSError(errno.EINVAL, "Invalid argument"))
+
+    def test_append_text_reraises_unrelated_oserror(self):
+        """Unit test for preserving unrelated stdout errors"""
+        cb = CliCallback(quiet=False)
+        with patch('sys.stdout') as mock_stdout:
+            mock_stdout.write.side_effect = OSError(errno.EIO, "I/O error")
+            with self.assertRaises(OSError) as cm:
+                cb.append_text("hello\n")
+        self.assertEqual(errno.EIO, cm.exception.errno)
 
     def test_return_text(self):
         """Check for correct text in output"""


### PR DESCRIPTION
## Summary

Handle interrupted CLI output on Windows so that closing a downstream pager such as `more` does not raise an unhandled `OSError` from `CliCallback.append_text()`.

## Root cause

When BleachBit preview output is piped into a pager and the pager is closed early, later writes to stdout can fail. On Windows this can surface as:

```text
OSError: [Errno 22] Invalid argument
```

The exception currently comes from `bleachbit/CLI.py::CliCallback.append_text()`, so a closed output pipe is treated like a cleaning failure and produces a traceback.

## Changes

- Track when CLI stdout has been interrupted and stop writing additional preview output after that point.
- Ignore only interrupted-output errors from `append_text()`:
  - `BrokenPipeError`
  - `OSError` with `errno.EPIPE` or `errno.EINVAL`
- Keep unrelated `OSError` values propagating.
- Add regression coverage for normal output, closed pipe output, Windows `EINVAL`, and unrelated stdout errors.

## Testing

Passed:

- `PYTHONWARNINGS=error uv run python -m unittest tests.TestCLI.CLITestCase.test_append_text_ignores_broken_pipe tests.TestCLI.CLITestCase.test_append_text_ignores_windows_invalid_argument tests.TestCLI.CLITestCase.test_append_text_reraises_unrelated_oserror tests.TestCLI.CLITestCase.test_append_text_writes_stdout -v`
  - `Ran 4 tests ... OK`
- `PYTHONWARNINGS=error uv run python -m unittest tests.TestCLI.CLITestCase.test_preview -v`
  - `Ran 1 test ... OK`
- `uv run python -m py_compile bleachbit/CLI.py tests/TestCLI.py`
- `git diff --check`
- `uv run python bleachbit.py -p system.tmp | uv run python -c "import sys; sys.stdin.readline(); sys.exit(0)"`
  - Exit code: `0`
  - Confirmed no `OSError: [Errno 22] Invalid argument` and no traceback from `append_text()`
- `uv run python bleachbit.py -p system.tmp | /c/Windows/System32/more.com`
  - Pressed `q` at the `-- More --` prompt
  - Exit code: `0`
  - Confirmed no traceback is printed

Also tried:

- `PYTHONWARNINGS=error uv run python -m unittest tests.TestCLI -v`
  - Result: fails in this local Windows source environment with two pre-existing/environmental failures unrelated to this change:
    - `test_args_to_operations_list`: `system.clipboard` expectation differs when GTK is unavailable
    - `test_gui_exit`: `--gui --exit` returns `1` because PyGObject/GTK is not installed
- `PYTHONWARNINGS=error uv run python -m unittest discover -p Test*.py -v`
  - Result: fails in this local Windows/Chinese-locale source environment with unrelated GTK, locale, and local filesystem/recycle-bin dependent failures
- `make tests PYTHON="uv run python"`
  - Not run successfully: `make` is not installed in this Git Bash environment

Local stderr during CLI runs still contains existing source-environment i18n warnings about missing `intl-8.dll`, but the interrupted stdout traceback is gone.

## Related issue

Fixes #2161
