### PR TITLE
Update and tighten GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: 'monthly'
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/test_ubuntu.yaml
+++ b/.github/workflows/test_ubuntu.yaml
@@ -11,7 +11,7 @@ on:
       - 'po/**'
       - 'README.md'
       - 'windows/**'
-  pull_request:  # Run on all pull requests
+  pull_request: # Run on all pull requests
     paths-ignore:
       - 'bleachbit.spec'
       - 'debian/**'
@@ -19,16 +19,21 @@ on:
       - 'po/**'
       - 'README.md'
       - 'windows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 # 2025-05-01: ubuntu-latest is currently 24.04, and its native
 # python version is 3.12.
 # native python for 22.04 is 3.10.
 jobs:
   test:
+    name: test (${{ matrix.python-version }})
     timeout-minutes: 25
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.9', '3.13', '3.14']
         include:
           - python-version: '3.9'
             ubuntu-version: ubuntu-22.04
@@ -54,86 +59,90 @@ jobs:
       COVERAGE: "coverage run"
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          appstream \
-          dbus \
-          dbus-x11 \
-          gettext \
-          gir1.2-gtk-3.0 \
-          gir1.2-notify-0.7 \
-          gnome-keyring \
-          libcairo2-dev \
-          libgirepository1.0-dev \
-          libnotify-bin \
-          libxml2-utils \
-          notification-daemon \
-          xvfb \
-          ${{ matrix.python-extra-dep }}
-        # for tests.TestLanguage
-        sudo locale-gen es_ES.UTF-8
-        sudo locale-gen pl_PL.UTF-8
-        sudo locale-gen en_AU.UTF-8
-        sudo update-locale
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            appstream \
+            dbus \
+            dbus-x11 \
+            gettext \
+            gir1.2-gtk-3.0 \
+            gir1.2-notify-0.7 \
+            gnome-keyring \
+            libcairo2-dev \
+            libgirepository1.0-dev \
+            libnotify-bin \
+            libxml2-utils \
+            notification-daemon \
+            xvfb \
+            ${{ matrix.python-extra-dep }}
+          # for tests.TestLanguage
+          sudo locale-gen es_ES.UTF-8
+          sudo locale-gen pl_PL.UTF-8
+          sudo locale-gen en_AU.UTF-8
+          sudo update-locale
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements.txt
 
-    - name: Update Python packages
-      run: |
-        pip list
-        python -m pip install --upgrade pip
+      - name: Update Python packages
+        run: |
+          pip list
+          python -m pip install --upgrade pip
 
-    - name: Install Python dependencies
-      run: |
-        pip install coverage coveralls appveyor-artifacts -r requirements.txt
-        if [ "${{ matrix.pygobject-version }}" != "" ]; then
-          pip install "PyGObject${{ matrix.pygobject-version }}"
-        fi
-        if [ "${{ matrix.python-version }}" == "3.14" ]; then
-          pip install pytest pytest-xdist
-        fi
+      - name: Install Python dependencies
+        run: |
+          pip install coverage coveralls appveyor-artifacts -r requirements.txt
+          if [ "${{ matrix.pygobject-version }}" != "" ]; then
+            pip install "PyGObject${{ matrix.pygobject-version }}"
+          fi
+          if [ "${{ matrix.python-version }}" == "3.14" ]; then
+            pip install pytest pytest-xdist
+          fi
 
-    - name: Generate Revision.py
-      run: |
-        echo "revision = \"`git rev-parse --short HEAD`\"" > bleachbit/Revision.py
-        echo "build_number = \"${{ github.run_number }}\"" >> bleachbit/Revision.py
+      - name: Generate Revision.py
+        run: |
+          echo "revision = \"`git rev-parse --short HEAD`\"" > bleachbit/Revision.py
+          echo "build_number = \"${{ github.run_number }}\"" >> bleachbit/Revision.py
 
-    - name: Generate translations
-      run: make -C po local bleachbit.pot
+      - name: Generate translations
+        run: make -C po local bleachbit.pot
 
-    - name: Run tests (regular and sudo)
-      timeout-minutes: ${{ matrix.test_timeout_minutes }}
-      run: |
-        export DISPLAY=":1.0"
-        export $(dbus-launch)
-        sudo Xvfb :1 -screen 0 800x600x24 &
-        sleep 5
-        if [ "${{ matrix.python-version }}" == "3.14" ]; then
-          dbus-run-session -- bash -c '/usr/lib/notification-daemon/notification-daemon & sleep 2 && xvfb-run -a bash -c "PYTHONPATH=. pytest -n auto"'
-        else
-          dbus-run-session -- bash -c '/usr/lib/notification-daemon/notification-daemon & sleep 2 && xvfb-run -a bash -c "make tests && make tests-with-sudo"'
-        fi
+      - name: Run tests (regular and sudo)
+        timeout-minutes: ${{ matrix.test_timeout_minutes }}
+        run: |
+          export DISPLAY=":1.0"
+          export $(dbus-launch)
+          sudo Xvfb :1 -screen 0 800x600x24 &
+          sleep 5
+          if [ "${{ matrix.python-version }}" == "3.14" ]; then
+            dbus-run-session -- bash -c '/usr/lib/notification-daemon/notification-daemon & sleep 2 && xvfb-run -a bash -c "PYTHONPATH=. pytest -n auto"'
+          else
+            dbus-run-session -- bash -c '/usr/lib/notification-daemon/notification-daemon & sleep 2 && xvfb-run -a bash -c "make tests && make tests-with-sudo"'
+          fi
 
-    # appveyor-artifacts does not work with Python 3.13, and running once
-    # is enough.
-    - name: Combine Linux and Windows coverage, upload to Coveralls
-      if: matrix.python-version == '3.9'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        echo "Linux-only coverage before combine:"
-        coverage report
-        mv .coverage .coverage.ubuntu
-        appveyor-artifacts -o az0 -n bleachbit -m -c ${{ github.sha }} download
-        mv .coverage .coverage.windows
-        echo "Combined coverage:"
-        coverage combine
-        coverage report
-        coveralls
+      # appveyor-artifacts does not work with Python 3.13, and running once
+      # is enough.
+      - name: Combine Linux and Windows coverage, upload to Coveralls
+        if: matrix.python-version == '3.9' && github.repository == 'bleachbit/bleachbit'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Linux-only coverage before combine:"
+          coverage report
+          mv .coverage .coverage.ubuntu
+          appveyor-artifacts -o az0 -n bleachbit -m -c ${{ github.sha }} download
+          mv .coverage .coverage.windows
+          echo "Combined coverage:"
+          coverage combine
+          coverage report
+          coveralls

--- a/.github/workflows/update_translation.yml
+++ b/.github/workflows/update_translation.yml
@@ -7,16 +7,24 @@ on:
     paths:
       - 'po/*.po' # translation changed
 
+permissions:
+  contents: read
+
 jobs:
   update-desktop:
+    if: github.repository == 'bleachbit/bleachbit'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # commit and push localization files
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -38,6 +46,8 @@ jobs:
         run: python3 windows/nsis_translations.py --generate
 
       - name: Commit if changed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name "GitHub Action"
           git config --global user.email "action@github.com"
@@ -46,6 +56,5 @@ jobs:
               echo "No changes to commit."
           else
               git commit -m 'Update localization files' -m 'Automatically extracted from ./po/*.po'
-              git push
+              git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:${{ github.ref_name }}"
           fi
-


### PR DESCRIPTION
* update actions to the latest versions
* add permissions
* add workflow_dispatch
* add `persist-credentials: false`
* cache pip
* add fail-fast: false
* guard translation updates and coverage to the main repo only
* format
* add dependabot config for action updates (monthly)

Non-whitespace diff: https://github.com/bleachbit/bleachbit/pull/2171/changes?w=1

Related #2170 