### PR TITLE
Avoid tempfile.mktemp in the symlink delete test

### DIFF
--- a/tests/TestFileUtilities.py
+++ b/tests/TestFileUtilities.py
@@ -623,7 +623,7 @@ State=AAAA/wA...
 
             # make symlink
             self.assertExists(srcname)
-            linkname = tempfile.mktemp('bblink')
+            linkname = os.path.join(self.tempdir,'bblink')
             self.assertNotExists(linkname)
             link_fn(srcname, linkname)
             self.assertExists(linkname)


### PR DESCRIPTION
This along with #2174 and #2171 should fix the current CodeQL issues.

Later, we can decide if it's worth switching to a tighter CodeQL queries suite.