### PR TITLE
Memory: fix regex so `SwapCached` is not counted as free

### DIFF
--- a/bleachbit/Memory.py
+++ b/bleachbit/Memory.py
@@ -206,7 +206,7 @@ def physical_free_linux():
     with open("/proc/meminfo") as f:
         for line in f:
             line = line.replace("\n", "")
-            ret = re.search(r'(MemFree|Cached):[ ]*([0-9]*) kB', line)
+            ret = re.search(r'^(MemFree|Cached):[ ]*([0-9]*) kB', line)
             if ret is not None:
                 kb = int(ret.group(2))
                 free_bytes += kb * 1024


### PR DESCRIPTION
I assume the syntax is the same as `grep -E`. The previous code matched `SwapCached` too:

```
grep -E "(MemFree|Cached):[ ]*([0-9]*) kB" /proc/meminfo
MemFree:        11845824 kB
Cached:          4168496 kB
SwapCached:            0 kB
```

The new one doesn't:

```
grep -E "^(MemFree|Cached):[ ]*([0-9]*) kB" /proc/meminfo
MemFree:        11840832 kB
Cached:          4168496 kB
```