### PR TITLE
Fix GTK crash from logging on worker threads

### DIFF
--- a/bleachbit/GuiWindow.py
+++ b/bleachbit/GuiWindow.py
@@ -7,6 +7,7 @@
 import logging
 import os
 import sys
+import threading
 import time
 
 import bleachbit
@@ -551,6 +552,11 @@ class GUI(Gtk.ApplicationWindow):
 
     def append_text(self, text, tag=None, __iter=None, scroll=True):
         """Add some text to the main log"""
+        if threading.current_thread() is not threading.main_thread():
+            # GTK isn't thread-safe, so push work from worker threads back
+            # onto the main loop instead of touching the buffer directly.
+            GLib.idle_add(self.append_text, text, tag, None, scroll)
+            return
         if self.textbuffer is None:
             # textbuffer was destroyed.
             return


### PR DESCRIPTION
I hit this on my branch where I switch to GitHub Actions. Maybe because the VMs are faster, not sure if this happens on AppVeyor too. For example: https://github.com/XhmikosR/bleachbit/actions/runs/29026213530/job/86146453315

> (org.bleachbit.BleachBit:7748): Gtk-WARNING **: 14:45:28.361: Invalid text buffer iterator: either the iterator is uninitialized, or the > characters/pixbufs/widgets in the buffer have been modified since the iterator was created.
> You must use marks, character numbers, or line numbers to preserve a position across buffer modifications.
> You can apply tags and insert marks without invalidating your iterators,
> but any mutation that affects 'indexable' buffer contents (contents that can be referred to by character offset)
> will invalidate all outstanding iterators
> Error: Process completed with exit code -1073741819.
