### PR TITLE
Tighten CodeQL and fix issues

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,8 @@ name: CodeQL
 on:
   push:
     branches:
-      - master
+      - '**'
+      - '!dependabot/**'
     paths-ignore:
       - 'appveyor.yml'
       - 'bleachbit.png'
@@ -20,7 +21,8 @@ on:
       - 'README.md'
   pull_request:
     branches:
-      - master
+      - '**'
+      - '!dependabot/**'
     paths-ignore:
       - 'appveyor.yml'
       - 'bleachbit.png'
@@ -77,7 +79,13 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-          # queries: +security-and-quality
+          config: |
+            queries:
+              - uses: security-and-quality
+            query-filters:
+              - exclude:
+                  problem.severity:
+                    - recommendation
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/bleachbit.py
+++ b/bleachbit.py
@@ -73,6 +73,7 @@ def main():
         # SIGPIPE status (128 + 13).
         devnull = os.open(os.devnull, os.O_WRONLY)
         os.dup2(devnull, sys.stdout.fileno())
+        os.close(devnull)
         sys.exit(141)
 
 

--- a/bleachbit/Action.py
+++ b/bleachbit/Action.py
@@ -19,7 +19,7 @@ from itertools import product
 from bleachbit import Command, FileUtilities, General, Special, DeepScan, Cookie as CookieMod  # mod=module
 from bleachbit import FS_SCAN_RE_FLAGS
 from bleachbit.Constant import CLEAN_FILE_LABEL
-from bleachbit.Cookie import COOKIE_KEEP_LIST_FILENAME, load_keep_list
+from bleachbit.Cookie import load_keep_list
 from bleachbit.Language import get_text as _
 
 if os.name == 'posix':

--- a/bleachbit/CLI.py
+++ b/bleachbit/CLI.py
@@ -403,6 +403,7 @@ There is NO WARRANTY, to the extent permitted by law.
             for _ret in bleachbit.Wipe.wipe_path(wipe_path):
                 pass
         sys.exit(0)
+    operations = {}
     if options.preview or options.clean:
         operations = args_to_operations(
             args, options.preset, options.all_but_warning, excludes)

--- a/bleachbit/Cleaner.py
+++ b/bleachbit/Cleaner.py
@@ -23,7 +23,7 @@ from bleachbit.PathUtils import path_equal
 from bleachbit.Process import is_process_running
 from bleachbit import Action, CleanerML, Command, FileUtilities, Memory
 from bleachbit import IS_LINUX, IS_POSIX, IS_WINDOWS
-from bleachbit.GtkShim import Gtk, Gdk, HAVE_GTK
+from bleachbit.GtkShim import Gtk, HAVE_GTK
 from bleachbit.Wipe import wipe_path
 
 if 'posix' == os.name:

--- a/bleachbit/GuiTreeModels.py
+++ b/bleachbit/GuiTreeModels.py
@@ -71,6 +71,7 @@ class TreeDisplayModel:
         assert isinstance(value, bool)
         assert isinstance(model, Gtk.TreeStore)
         cleaner_id = None
+        option_id = None
         i = path
         if isinstance(i, str):
             # type is either str or gtk.TreeIter

--- a/bleachbit/GuiWindow.py
+++ b/bleachbit/GuiWindow.py
@@ -110,6 +110,7 @@ class GUI(Gtk.ApplicationWindow):
         accel.connect(key, mod, Gtk.AccelFlags.VISIBLE, self.on_quit)
 
         # Enable the user to change font size with keyboard or mouse.
+        gtk_font_name = None
         try:
             gtk_font_name = Gtk.Settings.get_default().get_property('gtk-font-name')
         except TypeError as e:

--- a/bleachbit/GuiWindow.py
+++ b/bleachbit/GuiWindow.py
@@ -255,10 +255,10 @@ class GUI(Gtk.ApplicationWindow):
     def _get_windows10_theme_css(self):
         """Load the Windows 10 theme CSS files (if not already loaded)"""
         if not 'nt' == os.name:
-            return
+            return None
 
         if not options.get("win10_theme"):
-            return
+            return None
 
         # Load regular theme CSS
         dark_mode = options.get('dark_mode')

--- a/bleachbit/Memory.py
+++ b/bleachbit/Memory.py
@@ -77,7 +77,7 @@ def parse_swapoff(swapoff):
 def disable_swap_linux():
     """Disable Linux swap and return list of devices"""
     if 0 == count_swap_linux():
-        return
+        return None
     logger.debug(_("Disabling swap."))
     args = ["swapoff", "-a", "-v"]
     (rc, stdout, stderr) = General.run_external(args)

--- a/bleachbit/RecognizeCleanerML.py
+++ b/bleachbit/RecognizeCleanerML.py
@@ -16,7 +16,6 @@ import sys
 
 # first party imports
 from bleachbit.Language import get_text as _, pget_text as _p
-import bleachbit
 from bleachbit.CleanerML import list_cleanerml_files
 from bleachbit.Options import options
 

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -27,21 +27,16 @@ These are the terms:
 import atexit
 import base64
 import ctypes
-import decimal
 import errno
 import glob
 import hashlib
 import logging
 import ntpath
 import os
-import pathlib
 import re
 import shutil
-import struct
 import sys
-import threading
 import time
-import uuid
 import xml.dom.minidom
 from ctypes import wintypes
 from decimal import Decimal

--- a/bleachbit/Windows.py
+++ b/bleachbit/Windows.py
@@ -1055,12 +1055,12 @@ def load_i18n_dll():
     if not lib_path:
         logger.warning(
             'internationalization library was not found, so translations will not work.')
-        return
+        return None
     try:
         libintl = ctypes.cdll.LoadLibrary(lib_path)
     except Exception as e:
         logger.warning('error in LoadLibrary(%s): %s', lib_path, e)
-        return
+        return None
 
     # Configure DLL function prototypes
     libintl.bindtextdomain.argtypes = [ctypes.c_char_p, ctypes.c_char_p]

--- a/bleachbit/WindowsWipe.py
+++ b/bleachbit/WindowsWipe.py
@@ -941,8 +941,7 @@ def move_file(volume_handle, file_handle, starting_vcn,
 
     input_struct = struct.pack('IIqqII', handle_lo, handle_hi, starting_vcn,
                                starting_lcn, cluster_count, 0)
-    _vb_struct = DeviceIoControl(volume_handle, FSCTL_MOVE_FILE,
-                                 input_struct, None)
+    DeviceIoControl(volume_handle, FSCTL_MOVE_FILE, input_struct, None)
 
 
 def write_zero_fill(file_handle, write_length_bytes):

--- a/bleachbit/WindowsWipe.py
+++ b/bleachbit/WindowsWipe.py
@@ -210,8 +210,7 @@ def logical_ranges_to_extents(ranges, bridge_compressed=False):
             # clusters interspersed with -1 space-saver sections
             # that are arranged with gaps of 16 clusters or less.
             merge_index = index
-            while (lcn >= 0 and
-                   merge_index + 2 < last_record and
+            while (merge_index + 2 < last_record and
                    ranges[merge_index + 1][1] < 0 and
                    ranges[merge_index + 2][1] >= 0 and
                    ranges[merge_index + 2][1] - ranges[merge_index][1] <= 16 and

--- a/tests/TestCLI.py
+++ b/tests/TestCLI.py
@@ -77,12 +77,12 @@ class CLITestCase(common.BleachbitTestCase):
         # --all-but-warning
         o = args_to_operations_list(False, True)
         self.assertIsInstance(o, list)
-        self.assertTrue('google_chrome.cache' in o)
-        self.assertTrue('system.tmp' in o)
+        self.assertIn('google_chrome.cache', o)
+        self.assertIn('system.tmp', o)
         gui_available = IS_WINDOWS or HAVE_GTK
         self.assertEqual(gui_available, 'system.clipboard' in o)
-        self.assertFalse('system.empty_space' in o)
-        self.assertFalse('system.memory' in o)
+        self.assertNotIn('system.empty_space', o)
+        self.assertNotIn('system.memory', o)
 
     def test_args_to_operations(self):
         """Unit test for args_to_operations()"""
@@ -589,4 +589,4 @@ class CLITestCase(common.BleachbitTestCase):
         self.assertEqual(rc, 0)
         # Is the application still running?
         opened_windows_titles = common.get_opened_windows_titles()
-        self.assertFalse('BleachBit' in opened_windows_titles)
+        self.assertNotIn('BleachBit', opened_windows_titles)

--- a/tests/TestChaff.py
+++ b/tests/TestChaff.py
@@ -90,6 +90,7 @@ class ChaffTestCase(common.BleachbitTestCase):
                 return False
             if host == 'download.bleachbit.org':
                 return True
+            return None
         mock_download.side_effect = succeed_on_second
         ret = download_models(models_dir=tmp_dir)
         self.assertTrue(

--- a/tests/TestChaff.py
+++ b/tests/TestChaff.py
@@ -74,7 +74,7 @@ class ChaffTestCase(common.BleachbitTestCase):
                 self.assertIn('Subject: ', contents)
                 self.assertNotIn('base64', contents)
 
-        generated_file_names = generate_2600(5, tmp_dir, models_dir)
+        generate_2600(5, tmp_dir, models_dir)
 
         rmtree(tmp_dir)
 

--- a/tests/TestChaff.py
+++ b/tests/TestChaff.py
@@ -49,7 +49,7 @@ class ChaffTestCase(common.BleachbitTestCase):
         # ts = 2600 Magazine
         ts_path = os.path.join(models_dir, '2600_model.json.bz2')
 
-        for _i in ('download', 'already downloaded'):
+        for _ in ('download', 'already downloaded'):
             ret = download_models(models_dir=models_dir)
             self.assertIsInstance(ret, bool)
             self.assertTrue(

--- a/tests/TestCleaner.py
+++ b/tests/TestCleaner.py
@@ -333,7 +333,7 @@ class CleanerTestCase(common.BleachbitTestCase):
         for cmd in backends['system'].get_commands('cache'):
             for _ in cmd.execute(really_delete=False):
                 self.assertNotEqual(cmd.path, obexd_fn)
-                self.assertFalse('/.cache/obexd/' in cmd.path)
+                self.assertNotIn('/.cache/obexd/', cmd.path)
         from bleachbit.FileUtilities import delete
         delete(obexd_fn, ignore_missing=True)
 

--- a/tests/TestCleaner.py
+++ b/tests/TestCleaner.py
@@ -331,7 +331,7 @@ class CleanerTestCase(common.BleachbitTestCase):
         obexd_fn = os.path.join(obexd_dir, 'bleachbit-test')
         common.touch_file(obexd_fn)
         for cmd in backends['system'].get_commands('cache'):
-            for _result in cmd.execute(really_delete=False):
+            for _ in cmd.execute(really_delete=False):
                 self.assertNotEqual(cmd.path, obexd_fn)
                 self.assertFalse('/.cache/obexd/' in cmd.path)
         from bleachbit.FileUtilities import delete

--- a/tests/TestCommand.py
+++ b/tests/TestCommand.py
@@ -74,7 +74,7 @@ class CommandTestCase(common.BleachbitTestCase):
         self.assertGreater(os.path.getsize(path), 0)
 
         # preview
-        ret = next(cmd.execute(False))
+        next(cmd.execute(False))
         self.assertExists(path)
         self.assertGreater(os.path.getsize(path), 0)
 

--- a/tests/TestExternalCommand.py
+++ b/tests/TestExternalCommand.py
@@ -455,7 +455,7 @@ class ExternalCommandTestCase(common.BleachbitTestCase):
         """
         This tests covers elevate_privileges in the case where we pretend that we are not admin.
         """
-        self.assertTrue(os.name == 'nt')
+        self.assertEqual(os.name, 'nt')
         file_to_shred = self.mkstemp(prefix=fn_prefix)
         self.assertExists(file_to_shred)
 

--- a/tests/TestFileUtilities.py
+++ b/tests/TestFileUtilities.py
@@ -1036,7 +1036,7 @@ State=AAAA/wA...
                 temp.write('hello world')
                 temp.flush()
             with self.assertLogs('bleachbit.FileUtilities', level='WARNING') as cm:
-                det = detect_encoding(temp.name)
+                detect_encoding(temp.name)
             self.assertIn('chardet module is not available', cm.output[0])
             os.unlink(temp.name)
 

--- a/tests/TestFileUtilities.py
+++ b/tests/TestFileUtilities.py
@@ -1403,8 +1403,8 @@ State=AAAA/wA...
         self.assertGreater(len(paths1), 4)
         self.assertGreater(len(paths2), 4)
         paths12 = set(listdir((dir1, dir2)))
-        self.assertTrue(paths1 < paths12)
-        self.assertTrue(paths2 < paths12)
+        self.assertLess(paths1, paths12)
+        self.assertLess(paths2, paths12)
         # The individual calls should be equivalent to a combined call.
         self.assertSetEqual(paths1.union(paths2), paths12)
         # The directories should not be empty.

--- a/tests/TestGeneral.py
+++ b/tests/TestGeneral.py
@@ -399,6 +399,7 @@ class GeneralTestCase(common.BleachbitTestCase):
 
     def test_run_external_timeout(self):
         """Unit test for run_external() with timeout"""
+        args = None
         if IS_POSIX:
             args = ['sleep', '10']
         if IS_WINDOWS:

--- a/tests/TestGeneral.py
+++ b/tests/TestGeneral.py
@@ -9,7 +9,6 @@ Test case for module General
 """
 
 # standard library
-import copy
 import os
 import shutil
 import subprocess

--- a/tests/TestGtkShim.py
+++ b/tests/TestGtkShim.py
@@ -25,7 +25,6 @@ from bleachbit.GtkShim import (
     _handle_gtk_import_error,
     _patched_argv,
     _show_windows_error_dialog,
-    _try_import_gtk,
     path_has_lib_or_bin,
 )
 

--- a/tests/TestInit.py
+++ b/tests/TestInit.py
@@ -32,6 +32,7 @@ class InitTestCase(common.BleachbitTestCase):
         self.assertEqual(test_input, test_output)
 
         # should be expanded
+        test_inputs = ()
         if IS_WINDOWS:
             test_inputs = ('~', r'~\ntuser.dat')
         elif IS_POSIX:

--- a/tests/TestLanguage.py
+++ b/tests/TestLanguage.py
@@ -61,15 +61,15 @@ class LanguageTestCase(common.BleachbitTestCase):
         """Test get_supported_language_codes()"""
         slangs = get_supported_language_codes()
         self.assertTrue(isinstance(slangs, list))
-        self.assertTrue(len(slangs) > 1)
+        self.assertGreater(len(slangs), 1)
         for slang in slangs:
             if slang in common.SKIP_ALIAS_CODES:
                 continue
             self.assertIsLanguageCode(slang)
-        self.assertTrue('en_US' in slangs)
+        self.assertIn('en_US', slangs)
         if len(get_supported_language_codes()) < 3:
             self.skipTest('missing translations')
-        self.assertTrue('es' in slangs)
+        self.assertIn('es', slangs)
 
     def test_get_supported_language_code_name_dict_unknown_code(self):
         with mock.patch('bleachbit.Language.get_supported_language_codes', return_value=['en', 'es', 'foo@bar']):
@@ -106,7 +106,7 @@ class LanguageTestCase(common.BleachbitTestCase):
             setup_translation()
             text = get_text('Preview')
             self.assertIsInstance(text, str)
-            self.assertTrue(len(text) > 0)
+            self.assertGreater(len(text), 0)
 
     @skipIfMissingPo
     def test_get_text_au(self):

--- a/tests/TestOptions.py
+++ b/tests/TestOptions.py
@@ -11,8 +11,6 @@ Test case for module Options
 
 import errno
 import os
-import stat
-import subprocess
 import sys
 from unittest import mock
 

--- a/tests/TestOptions.py
+++ b/tests/TestOptions.py
@@ -223,9 +223,6 @@ check_online_updates=True
         self.assertEqual(o.config.getboolean('test', 'test_f_upper'), False)
         self.assertEqual(o.config.getboolean('test', 'test_f_lower'), False)
 
-        # clean up
-        del o
-
     def test_percent(self):
         """Test that the percent sign can be used without quoting the string"""
         # https://github.com/bleachbit/bleachbit/issues/205
@@ -237,9 +234,6 @@ check_online_updates=True
 
         # read
         self.assertEqual(opt.get('test', 'filename'), '/var/log/samba/log.%m')
-
-        # clean up
-        del opt
 
     def test_error_disk_full(self):
         """Test graceful degradation when disk is full"""

--- a/tests/TestProcess.py
+++ b/tests/TestProcess.py
@@ -139,6 +139,7 @@ root               531   0.0  0.0  2501712    588   ??  Ss   20May16   0:02.40 s
         # handles symlinks.
         # sys.executable may look like /usr/bin/python3
         # When running under `env -i`, then sys.executable is empty.
+        exe = None
         if sys.executable:
             exe = os.path.basename(os.path.realpath(sys.executable))
         else:

--- a/tests/TestProtectedPath.py
+++ b/tests/TestProtectedPath.py
@@ -224,6 +224,7 @@ class ProtectedPathTestCase(common.BleachbitTestCase):
             result = check_protected_path(tmpdir)
             self.assertIsNone(result)
         # Check .git (which is protected) under an exempt directory
+        exempt_dir_raw = None
         if IS_POSIX:
             exempt_dir_raw = '~/.cache'
         elif IS_WINDOWS:

--- a/tests/TestProtectedPath.py
+++ b/tests/TestProtectedPath.py
@@ -173,7 +173,7 @@ class ProtectedPathTestCase(common.BleachbitTestCase):
         """Test check_exempt() on Windows"""
         temp_dir = expand_path('%temp%')
         self.assertIsInstance(temp_dir, str)
-        self.assertTrue(len(temp_dir) > 0)
+        self.assertGreater(len(temp_dir), 0)
         for case_method in CASE_METHODS:
             cased_temp_dir = case_method(temp_dir)
             self.assertTrue(_check_exempt(cased_temp_dir),
@@ -235,7 +235,7 @@ class ProtectedPathTestCase(common.BleachbitTestCase):
         self.assertIsInstance(exempt_dir, str)
         self.assertTrue(_check_exempt(exempt_dir))
         self.assertNotEqual(exempt_dir, exempt_dir_raw)
-        self.assertTrue(len(exempt_dir) > 0)
+        self.assertGreater(len(exempt_dir), 0)
         result = check_protected_path(exempt_dir)
         self.assertIsNone(result)
         subpath = os.path.join(exempt_dir, '.git')

--- a/tests/TestSystemInformation.py
+++ b/tests/TestSystemInformation.py
@@ -192,4 +192,4 @@ __file__ = /home/regularuser/software/bleachbit/bleachbit/SystemInformation.py""
         # Both should be non-empty strings
         self.assertIsString(original)
         self.assertIsString(anonymized)
-        self.assertTrue(len(anonymized) > 0)
+        self.assertGreater(len(anonymized), 0)

--- a/tests/TestSystemInformation.py
+++ b/tests/TestSystemInformation.py
@@ -106,6 +106,7 @@ os.getenv(LocalAppData) = {home_dir}\\AppData\\Local"""
         username = '我可以喝漂白剂而不伤及自身'
         unicode_dir = self.mkdir(username)
 
+        short_path = None
         try:
             import win32api
             short_path = win32api.GetShortPathName(unicode_dir)

--- a/tests/TestVFS.py
+++ b/tests/TestVFS.py
@@ -34,7 +34,7 @@ class VFSTestCase(common.BleachbitTestCase):
         self.assertTrue(vfs.isdir('/'))
         root_children = vfs.listdir('/' if IS_POSIX else 'C:\\')
         self.assertIsInstance(root_children, list)
-        self.assertTrue(len(root_children) > 0)
+        self.assertGreater(len(root_children), 0)
         self.assertTrue(all(isinstance(child, str) for child in root_children))
         if IS_POSIX:
             self.assertIn('tmp', root_children)

--- a/tests/TestWindows.py
+++ b/tests/TestWindows.py
@@ -16,7 +16,6 @@ import os
 import platform
 import shutil
 import subprocess
-import sys
 import tempfile
 import time
 from decimal import Decimal

--- a/tests/TestWorker.py
+++ b/tests/TestWorker.py
@@ -30,6 +30,7 @@ class AccessDeniedActionAction(ActionProvider):
     action_key = 'access.denied'
 
     def __init__(self, action_element):
+        ActionProvider.__init__(self, action_element)
         self.pathname = action_element.getAttribute('path')
 
     def get_commands(self):
@@ -47,6 +48,7 @@ class DoesNotExistAction(ActionProvider):
     action_key = 'does.not.exist'
 
     def __init__(self, action_element):
+        ActionProvider.__init__(self, action_element)
         self.pathname = action_element.getAttribute('path')
 
     def get_commands(self):
@@ -64,6 +66,7 @@ class FunctionGeneratorAction(ActionProvider):
     action_key = 'function.generator'
 
     def __init__(self, action_element):
+        ActionProvider.__init__(self, action_element)
         self.pathname = action_element.getAttribute('path')
 
     def get_commands(self):
@@ -80,6 +83,7 @@ class FunctionPathAction(ActionProvider):
     action_key = 'function.path'
 
     def __init__(self, action_element):
+        ActionProvider.__init__(self, action_element)
         self.pathname = action_element.getAttribute('path')
 
     def get_commands(self):
@@ -97,6 +101,7 @@ class InvalidEncodingAction(ActionProvider):
     action_key = 'invalid.encoding'
 
     def __init__(self, action_element):
+        ActionProvider.__init__(self, action_element)
         self.pathname = action_element.getAttribute('path')
 
     def get_commands(self):
@@ -113,6 +118,7 @@ class FunctionPlainAction(ActionProvider):
     action_key = 'function.plain'
 
     def __init__(self, action_element):
+        ActionProvider.__init__(self, action_element)
         self.pathname = action_element.getAttribute('path')
 
     def get_commands(self):
@@ -130,6 +136,7 @@ class LockedAction(ActionProvider):
     action_key = 'locked'
 
     def __init__(self, action_element):
+        ActionProvider.__init__(self, action_element)
         self.pathname = action_element.getAttribute('path')
 
     def get_commands(self):
@@ -156,6 +163,7 @@ class RuntimeErrorAction(ActionProvider):
     action_key = 'runtime'
 
     def __init__(self, action_element):
+        ActionProvider.__init__(self, action_element)
         self.pathname = action_element.getAttribute('path')
 
     def get_commands(self):
@@ -173,6 +181,7 @@ class TruncateTestAction(ActionProvider):
     action_key = 'truncate.test'
 
     def __init__(self, action_element):
+        ActionProvider.__init__(self, action_element)
         self.pathname = action_element.getAttribute('path')
 
     def get_commands(self):

--- a/tests/common.py
+++ b/tests/common.py
@@ -246,7 +246,7 @@ class BleachbitTestCase(unittest.TestCase):
         self.assertIsInstance(lang_id, str)
         if lang_id in ('C', 'C.UTF-8', 'C.utf8', 'POSIX'):
             return
-        self.assertTrue(len(lang_id) >= 2)
+        self.assertGreaterEqual(len(lang_id), 2)
         pattern = r'^[a-z]{2,3}([_-]([A-Z][A-Za-z]{1,3}|[0-9]{3}))?(\.[a-zA-Z][a-zA-Z0-9-]+)?(@\w+)?$'
         self.assertTrue(re.match(pattern, lang_id),
                         f'Invalid language code format: {lang_id}')


### PR DESCRIPTION
The two Actions' issues will be fixed by #2171. The insecure temporary file in tests should be fixed by #2175.

The new issue about "Overly permissive file permissions" in tests should be ignored in the Security tab -> Code scanning -> click the alert -> Dismiss -> reason "Used in tests".

@az0: if you want me to change the branches CodeQL runs, let me know.