### PR TITLE
Validate data with real checks instead of assert

### DIFF
--- a/bleachbit/CLI.py
+++ b/bleachbit/CLI.py
@@ -101,7 +101,8 @@ def args_to_operations_list(preset, all_but_warning):
     args = []
     if not backends:
         list(register_cleaners())
-    assert len(backends) > 1
+    if len(backends) == 0:
+        raise RuntimeError('no cleaners registered')
     for key in sorted(backends):
         c_id = backends[key].get_id()
         for (o_id, _o_name) in backends[key].get_options():

--- a/bleachbit/Cookie.py
+++ b/bleachbit/Cookie.py
@@ -171,7 +171,8 @@ def delete_cookies(path, keep_list, really_delete=False):
     (table_name, host_column) = detect_browser(path)
 
     original_size = _get_db_disk_size(path)
-    assert original_size > 0
+    if original_size <= 0:
+        raise RuntimeError(f"cookies database is empty: {path}")
 
     # Set up connection
     uri = f'file:{path}'

--- a/bleachbit/FileUtilities.py
+++ b/bleachbit/FileUtilities.py
@@ -631,7 +631,9 @@ def execute_sqlite3(path, cmds):
         # https://www.sqlite.org/pragma.html#pragma_secure_delete
         if options.get('shred'):
             conn.execute('PRAGMA secure_delete=ON')
-            assert conn.execute('PRAGMA secure_delete').fetchone()[0] == 1
+            # Without this, shredding can leave freed content recoverable.
+            if conn.execute('PRAGMA secure_delete').fetchone()[0] != 1:
+                raise RuntimeError(f'could not enable secure_delete on {path}')
 
         for cmd in cmds.split(';'):
             try:

--- a/bleachbit/Network.py
+++ b/bleachbit/Network.py
@@ -161,7 +161,8 @@ def fetch_url(url, max_retries=3, backoff_factor=0.5, timeout=60,
         requests.RequestException: If there is an error fetching the URL
     """
     assert isinstance(url, str)
-    assert url.startswith('http'), f"URL must start with http, got {url}"
+    if not url.startswith('http'):
+        raise ValueError(f'URL must start with http, got {url}')
     assert isinstance(max_retries, int)
     assert max_retries >= 0
     assert isinstance(backoff_factor, float)

--- a/bleachbit/Special.py
+++ b/bleachbit/Special.py
@@ -46,7 +46,8 @@ def __get_chrome_history(path, fn='History'):
     path_history = os.path.join(os.path.dirname(path), fn)
     ver = get_sqlite_int(
         path_history, 'select value from meta where key="version"')[0]
-    assert ver > 1
+    if ver <= 1:
+        raise RuntimeError(f'unexpected Chrome history version: {ver}')
     return ver
 
 

--- a/bleachbit/SystemInformation.py
+++ b/bleachbit/SystemInformation.py
@@ -165,11 +165,13 @@ def get_version(four_parts=False):
         pass
 
     build_number = build_number_src or build_number_env
+    if build_number and not str(build_number).isdigit():
+        logger.warning('ignoring non-numeric build number: %r', build_number)
+        build_number = None
     if not build_number:
         if not four_parts:
             return bleachbit.APP_VERSION
         return f'{bleachbit.APP_VERSION}.0'
-    assert build_number.isdigit()
     return f'{bleachbit.APP_VERSION}.{build_number}'
 
 

--- a/bleachbit/Update.py
+++ b/bleachbit/Update.py
@@ -118,14 +118,16 @@ def check_updates(check_beta, check_winapp2, append_text, cb_success):
         return ()
 
     def parse_updates(element):
-        if element:
-            ver = element[0].getAttribute('ver')
-            url = element[0].firstChild.data
-            assert isinstance(ver, str)
-            assert isinstance(url, str)
-            assert url.startswith('http')
-            return ver, url
-        return ()
+        if not element:
+            return ()
+        ver = element[0].getAttribute('ver')
+        url = element[0].firstChild.data
+        if not (isinstance(ver, str) and isinstance(url, str)
+                and url.startswith('http')):
+            logger.warning('ignoring malformed update entry: ver=%r, url=%r',
+                           ver, url)
+            return ()
+        return ver, url
 
     stable = parse_updates(dom.getElementsByTagName("stable"))
     beta = parse_updates(dom.getElementsByTagName("beta"))

--- a/bleachbit/WindowsWipe.py
+++ b/bleachbit/WindowsWipe.py
@@ -976,7 +976,6 @@ def write_zero_fill(file_handle, write_length_bytes):
     # There is no need to explicitly move the file pointer while
     # writing. We are writing contiguously.
     while write_length_bytes > 0:
-        assert write_length_bytes > 0
         if write_length_bytes >= WRITE_BUF_SIZE:
             write_string = ZERO_FILL_BUFFER
             write_length_bytes -= WRITE_BUF_SIZE

--- a/bleachbit/WindowsWipe.py
+++ b/bleachbit/WindowsWipe.py
@@ -185,7 +185,8 @@ def logical_ranges_to_extents(ranges, bridge_compressed=False):
             # Keep track of VCN inside this file.
             this_vcn_span = vcn - vcn_count
             vcn_count = vcn
-            assert this_vcn_span >= 0
+            if this_vcn_span < 0:
+                raise RuntimeError(f'negative VCN span: {this_vcn_span}')
 
             yield (lcn, lcn + this_vcn_span - 1)
 
@@ -223,7 +224,8 @@ def logical_ranges_to_extents(ranges, bridge_compressed=False):
                 index += 1
                 this_vcn_span = vcn - vcn_count
                 vcn_count = vcn
-                assert this_vcn_span >= 0
+                if this_vcn_span < 0:
+                    raise RuntimeError(f'negative VCN span: {this_vcn_span}')
                 yield (lcn, lcn + this_vcn_span - 1)
             else:
                 index = merge_index + 1
@@ -231,7 +233,8 @@ def logical_ranges_to_extents(ranges, bridge_compressed=False):
                                  ranges[merge_index - 1][0])
                 vcn = ranges[merge_index][0]
                 vcn_count = vcn
-                assert last_vcn_span >= 0
+                if last_vcn_span < 0:
+                    raise RuntimeError(f'negative VCN span: {last_vcn_span}')
                 yield (lcn, ranges[merge_index][1] + last_vcn_span - 1)
 
 
@@ -737,7 +740,8 @@ def get_extents(file_handle, translate_to_extents=True, filename="<unknown>"):
 
     # If we make the GET_RETRIEVAL_POINTERS request with 0,
     # this should always come back 0.
-    assert starting_vcn == 0
+    if starting_vcn != 0:
+        raise RuntimeError(f'unexpected starting VCN: {starting_vcn}')
 
     # Populate the extents array with the ranges from rp structure.
     ranges = []
@@ -830,7 +834,8 @@ def get_volume_bitmap(volume_handle, total_clusters):
 
     # If we make the GET_VOLUME_BITMAP request with 0,
     # this should always come back 0.
-    assert starting_lcn == 0
+    if starting_lcn != 0:
+        raise RuntimeError(f'unexpected starting LCN: {starting_lcn}')
 
     # The remaining part of the structure is the actual bitmap.
     return volume_bitmap, bitmap_size
@@ -866,7 +871,9 @@ def get_ntfs_volume_data(volume_handle):
     mft_zone_end, vd_struct = unpack_element('q', vd_struct)     # 8 bytes
 
     # Quick sanity check that we got something reasonable for MFT zone.
-    assert mft_zone_start < mft_zone_end and mft_zone_start > 0 and mft_zone_end > 0
+    if not 0 < mft_zone_start < mft_zone_end:
+        raise RuntimeError(
+            f'invalid MFT zone bounds: {mft_zone_start}, {mft_zone_end}')
 
     logger.debug("MFT from %d to %d", mft_zone_start, mft_zone_end)
     return mft_zone_start, mft_zone_end
@@ -982,7 +989,10 @@ def write_zero_fill(file_handle, write_length_bytes):
         # by the number of bytes written (bytes_written).
         # logger.debug("Write %d bytes", len(write_string))
         _, bytes_written = WriteFile(file_handle, write_string)
-        assert bytes_written == len(write_string)
+        if bytes_written != len(write_string):
+            raise OSError(
+                f'incomplete wipe write: {bytes_written} of '
+                f'{len(write_string)} bytes')
 
     # Ensure all data is written to disk, not just cached in memory
     FlushFileBuffers(file_handle)
@@ -1009,7 +1019,8 @@ def wipe_file_direct(file_handle, extents, cluster_size, file_size):
     If the file had no extents (very small files stored in the MFT),
     we write zeros for the entire file size.
     """
-    assert cluster_size > 0
+    if cluster_size <= 0:
+        raise RuntimeError(f'invalid cluster size: {cluster_size}')
 
     # Remember that file_size measures full expanded content of the file,
     # which may not always match with size on disk (eg. if file compressed).
@@ -1059,7 +1070,8 @@ def wipe_extent_by_defrag(volume_handle, lcn_start, lcn_end, cluster_size,
     Returns:
         bool: True if wiping succeeded, False otherwise
     """
-    assert cluster_size > 0
+    if cluster_size <= 0:
+        raise RuntimeError(f'invalid cluster size: {cluster_size}')
     logger.debug("Examining extent from %d to %d for wipe...",
                  lcn_start, lcn_end)
     write_length = (lcn_end - lcn_start + 1) * cluster_size


### PR DESCRIPTION
Asserts are stripped under python -O (and -OO in the frozen Windows build), so checks on untrusted input or safety invariants vanish in release builds.

This is potentially breaking and I only tested this on my Windows dev machine, but better fail loud that swallow the failure and cause bad side effects.

Please have a close look and let me know if you want me to make any changes.