### PR TITLE
Further action tweaks

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -31,12 +31,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # 2025-05-01: ubuntu-latest is currently 24.04, and its native
 # python version is 3.12.
 # native python for 22.04 is 3.10.
 jobs:
   linux:
     name: linux (${{ matrix.python-version }})
+    runs-on: ${{ matrix.ubuntu-version }}
     timeout-minutes: 25
     strategy:
       fail-fast: false
@@ -55,9 +60,6 @@ jobs:
             python-extra-dep: 'libgirepository-2.0-dev'
             pygobject-version: ''
 
-    runs-on: ${{ matrix.ubuntu-version }}
-
-    # https://docs.github.com/en/actions/reference/workflows-and-actions/variables
     env:
       COVERAGE: "coverage run"
 

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -244,13 +244,13 @@ jobs:
           "version=$version" >> $env:GITHUB_OUTPUT
 
       - name: Generate translations
-        shell: cmd
+        shell: cmd # zizmor: ignore[misfeature] cmd is required for MSYS make, psexec, and .bat wrappers
         run: |
           set PATH=%MSYS_BIN%;%PATH%
           make PYTHON="%PYTHON_EXE%" -C po local bleachbit.pot
 
       - name: Build executable and installers
-        shell: cmd
+        shell: cmd # zizmor: ignore[misfeature] cmd is required for MSYS make, psexec, and .bat wrappers
         run: |
           set PATH=%MSYS_BIN%;%PATH%
           "%PYTHON_EXE%" -m windows.setup
@@ -332,18 +332,18 @@ jobs:
           Set-Content -Path bleachbit\Revision.py -Encoding utf8 -Value "revision = `"$rev`"`nbuild_number = `"$env:GITHUB_RUN_NUMBER`""
 
       - name: Generate translations
-        shell: cmd
+        shell: cmd # zizmor: ignore[misfeature] cmd is required for MSYS make, psexec, and .bat wrappers
         run: |
           set PATH=%MSYS_BIN%;%PATH%
           make PYTHON="%PYTHON_EXE%" -C po local bleachbit.pot
 
       - name: Install test dependencies
-        shell: cmd
+        shell: cmd # zizmor: ignore[misfeature] cmd is required for MSYS make, psexec, and .bat wrappers
         run: '"%PYTHON_HOME%\Scripts\pip3.exe" install --disable-pip-version-check -r requirements-test.txt'
 
       - name: Run admin tests
         if: matrix.suite == 'admin'
-        shell: cmd
+        shell: cmd # zizmor: ignore[misfeature] cmd is required for MSYS make, psexec, and .bat wrappers
         env:
           DESTRUCTIVE_TESTS: T
           PYTHONWARNINGS: error
@@ -354,21 +354,21 @@ jobs:
 
       - name: Run non-admin tests
         if: matrix.suite == 'nonadmin'
-        shell: cmd
+        shell: cmd # zizmor: ignore[misfeature] cmd is required for MSYS make, psexec, and .bat wrappers
         run: |
           set PATH=%MSYS_BIN%;C:\ProgramData\chocolatey\bin;C:\Windows\system32;C:\Windows;C:\Windows\system32\wbem;C:\Windows\SysWOW64\WindowsPowerShell\v1.0\
           call windows\run-psexec-nonadmin-tests.bat
 
       - name: Run low-integrity tests
         if: matrix.suite == 'low-integrity'
-        shell: cmd
+        shell: cmd # zizmor: ignore[misfeature] cmd is required for MSYS make, psexec, and .bat wrappers
         run: |
           set PATH=%MSYS_BIN%;C:\ProgramData\chocolatey\bin;C:\Windows\system32;C:\Windows;C:\Windows\system32\wbem;C:\Windows\SysWOW64\WindowsPowerShell\v1.0\
           call windows\run-psexec-low-integrity-tests.bat
 
       - name: Collect low-integrity coverage
         if: matrix.suite == 'low-integrity' && github.repository == 'bleachbit/bleachbit'
-        shell: cmd
+        shell: cmd # zizmor: ignore[misfeature] cmd is required for MSYS make, psexec, and .bat wrappers
         run: copy /Y "%USERPROFILE%\AppData\LocalLow\.coverage.psexec" .coverage.psexec
 
       - name: Upload coverage artifact

--- a/.github/workflows/test_macos.yaml
+++ b/.github/workflows/test_macos.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '**'
+      - '!dependabot/**' # avoid duplicate runs; the pull_request event handles dependabot PRs
     paths:
       - '**'
       - '!bleachbit.spec'
@@ -28,18 +29,21 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Headless tests on macOS. GTK is not installed, so GUI tests
 # auto-skip via @unittest.skipUnless(HAVE_GTK, ...).
 jobs:
   test:
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-latest]
         python-version: ['3.12']
-
-    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/update_translation.yml
+++ b/.github/workflows/update_translation.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Commit if changed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           git config --global user.name "GitHub Action"
           git config --global user.email "action@github.com"
@@ -56,5 +58,5 @@ jobs:
               echo "No changes to commit."
           else
               git commit -m 'Update localization files' -m 'Automatically extracted from ./po/*.po'
-              git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:${{ github.ref_name }}"
+              git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git" "HEAD:${REF_NAME}"
           fi

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,43 @@
+name: zizmor
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!dependabot/**' # avoid duplicate runs; the pull_request event handles dependabot PRs
+    paths:
+      - '.github/**'
+  pull_request:
+    branches:
+      - '**'
+    paths:
+      - '.github/**'
+  schedule:
+    - cron: '30 5 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      security-events: write # upload SARIF to code scanning
+      contents: read
+      actions: read
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0


### PR DESCRIPTION
I'm not 100% sure I like concurrency. Because if one pushes too fast, the older individual commit runs will be skipped. But this is consistent with the other workflows.

If you decide to drop it, it should be done for all workflows (minus the CodeQL one, probably).

I'll add zizmor because it can save your a** nowadays from things that CodeQL doesn't cover yet.