### PR TITLE
Windows: fix missing plyer notification backend in frozen build

### DIFF
--- a/windows/setup.py
+++ b/windows/setup.py
@@ -319,7 +319,7 @@ def build_py2exe():
         'compressed': 1,     # Create compressed archive
         'optimize': 2,       # Extra optimization (like python -OO)
         'includes': ['gi'],
-        'packages': ['chardet', 'encodings', 'gi', 'gi.overrides', 'plyer'],
+        'packages': ['chardet', 'encodings', 'gi', 'gi.overrides', 'plyer.platforms.win.notification'],
         'excludes': ['pyreadline', 'difflib', 'doctest',
                      'pickle', 'ftplib', 'bleachbit.Unix', 'charset_normalizer',
                      'setuptools', 'tomli', 'wheel', 'backports',


### PR DESCRIPTION
I hit this with the portable main build:

```
Traceback (most recent call last):
  File "plyer\utils.pyc", line 96, in _ensure_obj
ModuleNotFoundError: No module named 'plyer.platforms'
Traceback (most recent call last):
  File "bleachbit\Worker.pyc", line 347, in run
  File "bleachbit\GuiWindow.pyc", line 779, in worker_done
  File "bleachbit\GuiUtil.pyc", line 236, in notify
  File "bleachbit\GuiUtil.pyc", line 292, in notify_plyer
  File "plyer\facades\notification.pyc", line 84, in notify
  File "plyer\facades\notification.pyc", line 93, in _notify
NotImplementedError: No usable implementation found!
```

Testing to see if the change fixes it.