### PR TITLE
Remove deprecated app menu

### DIFF
--- a/bleachbit/GuiApplication.py
+++ b/bleachbit/GuiApplication.py
@@ -100,24 +100,11 @@ class Bleachbit(Gtk.Application):
     def build_app_menu(self):
         """Build the application menu
 
-        On Linux with GTK 3.24, this code is necessary but not sufficient for
-        the menu to work. The headerbar code is also needed.
-
-        On Windows with GTK 3.18, this code is sufficient for the menu to work.
+        This code is necessary but not sufficient for the menu to work. The
+        headerbar code is also needed.
         """
         from bleachbit.Language import setup_translation
         setup_translation()
-
-        # set_translation_domain() seems to have no effect.
-        # builder.set_translation_domain('bleachbit')
-        app_menu_path = bleachbit.get_share_path('app-menu.ui')
-        if app_menu_path:
-            builder = Gtk.Builder()
-            builder.add_from_file(app_menu_path)
-            menu = builder.get_object('app-menu')
-            self.set_app_menu(menu)
-        else:
-            logger.error('build_app_menu(): app-menu.ui not found')
 
         # set up mappings between <attribute name="action"> in app-menu.ui and methods in this class
         actions = {'shredFiles': self.cb_shred_file,

--- a/bleachbit/GuiWindow.py
+++ b/bleachbit/GuiWindow.py
@@ -1141,10 +1141,6 @@ class GUI(Gtk.ApplicationWindow):
         hbar.pack_start(box)
 
         # Add hamburger menu on the right.
-        # This is not needed for Microsoft Windows because other code places its
-        # menu on the left side.
-        if IS_WINDOWS:
-            return hbar
         menu_button = Gtk.MenuButton()
         icon = Gio.ThemedIcon(name="open-menu-symbolic")
         image = Gtk.Image.new_from_gicon(icon, Gtk.IconSize.BUTTON)


### PR DESCRIPTION
It has not been used for years. Use the hamburger menu also on Windows.

See: https://wiki.gnome.org/Design/Whiteboards/AppMenuMigration