### PR TITLE
tests: do not expect a clipboard option on Windows without GTK

### DIFF
--- a/tests/TestCLI.py
+++ b/tests/TestCLI.py
@@ -79,8 +79,9 @@ class CLITestCase(common.BleachbitTestCase):
         self.assertIsInstance(o, list)
         self.assertIn('google_chrome.cache', o)
         self.assertIn('system.tmp', o)
-        gui_available = IS_WINDOWS or gtk_may_be_available()
-        self.assertEqual(gui_available, 'system.clipboard' in o)
+        # The clipboard option is added only when GTK may be available,
+        # regardless of the operating system.  See Cleaner.System.
+        self.assertEqual(gtk_may_be_available(), 'system.clipboard' in o)
         self.assertNotIn('system.empty_space', o)
         self.assertNotIn('system.memory', o)
 


### PR DESCRIPTION
Closes #2241

`Cleaner.System` adds the `clipboard` option only when `gtk_may_be_available()` is true, on every platform, but `test_args_to_operations_list` expected it whenever `IS_WINDOWS` was true. On a Windows Python environment built without GTK (CLI/TUI/wxWidgets setups) the assertion fails with `True != False`.

Aligned the expectation with `Cleaner.System`. Verified by patching `IS_WINDOWS` to `True` in a GTK-less environment: the assertion fails before the change and passes after; `tests/TestCLI.py` is 33 passed, 1 skipped.
