### PR TITLE
Fix missing menu on Windows

### DIFF
--- a/bleachbit/GuiApplication.py
+++ b/bleachbit/GuiApplication.py
@@ -96,12 +96,9 @@ class Bleachbit(Gtk.Application):
         return application_id_suffix
 
     def build_app_menu(self):
-        """Build the application menu
+        """Register the actions used by the application menu
 
-        On Linux with GTK 3.24, this code is necessary but not sufficient for
-        the menu to work. The headerbar code is also needed.
-
-        On Windows with GTK 3.18, this code is sufficient for the menu to work.
+        The menu itself is built by the headerbar code in GuiWindow.
         """
         from bleachbit.Language import setup_translation
         setup_translation()

--- a/bleachbit/GuiWindow.py
+++ b/bleachbit/GuiWindow.py
@@ -1140,11 +1140,7 @@ class GUI(Gtk.ApplicationWindow):
 
         hbar.pack_start(box)
 
-        # Add hamburger menu on the right.
-        # This is not needed for Microsoft Windows because other code places its
-        # menu on the left side.
-        if IS_WINDOWS:
-            return hbar
+        # Add hamburger menu on the right
         menu_button = Gtk.MenuButton()
         icon = Gio.ThemedIcon(name="open-menu-symbolic")
         image = Gtk.Image.new_from_gicon(icon, Gtk.IconSize.BUTTON)

--- a/windows/setup.py
+++ b/windows/setup.py
@@ -672,6 +672,7 @@ def delete_icons():
         'edit-find.png',
         'list-add-symbolic.svg',  # spin box in chaff dialog
         'list-remove-symbolic.svg',  # spin box in chaff dialog
+        'open-menu-symbolic.svg',  # hamburger menu on headerbar
         'pan-down-symbolic.svg',  # there is no pan-down.png
         'pan-end-symbolic.svg',  # there is no pan-end.png
         'process-stop.png',  # abort on toolbar


### PR DESCRIPTION
Regression from a2b1a6da.

I can only test on Windows, unsure about other platforms. BTW a2b1a6da is merged on master but #2229 is not. Another solution would be to revert the offending patch.

Fixes #2246 