### PR TITLE
Fix CLI KeyError on -cleaner.option negation

### DIFF
--- a/bleachbit/CLI.py
+++ b/bleachbit/CLI.py
@@ -130,7 +130,9 @@ def args_to_operations(args, preset, all_but_warning, excludes=None):
     """Convert command-line arguments to a dictionary of operations
 
     Args:
-        args: List of cleaner.option strings (e.g., ['system.tmp', 'firefox.cache'])
+        args: List of cleaner.option strings (e.g., ['system.tmp', 'firefox.cache']).
+            An argument prefixed with '-' (e.g., '-system.recycle_bin') is treated
+            as an exclusion, the same as passing it via --except.
         preset: Boolean indicating whether to use saved preset operations
         all_but_warning: Boolean indicating whether to include all non-warning operations
         excludes: Optional list of cleaner.option strings to remove from operations
@@ -146,8 +148,25 @@ def args_to_operations(args, preset, all_but_warning, excludes=None):
 
     if excludes is None:
         excludes = []
+    else:
+        # Copy so the leading-'-' negations below are not appended to the
+        # caller's list.
+        excludes = list(excludes)
+
+    # Support the leading '-' negation syntax (e.g. 'system.*'
+    # '-system.recycle_bin') by routing negated arguments into the same
+    # exclusion path as --except.  Without this, '-system.recycle_bin' was
+    # treated as a cleaner literally named '-system', which later raised a
+    # KeyError in Worker.run_operations.
+    included_args = []
+    for arg in args:
+        if arg.startswith('-') and len(arg) > 1:
+            excludes.append(arg[1:])
+        else:
+            included_args.append(arg)
+
     positive_args = set(
-        args + args_to_operations_list(preset, all_but_warning))
+        included_args + args_to_operations_list(preset, all_but_warning))
 
     def fix_deprecated(cid, oid):
         if 'system' == cid and 'free_disk_space' == oid:

--- a/tests/TestCLI.py
+++ b/tests/TestCLI.py
@@ -94,7 +94,15 @@ class CLITestCase(common.BleachbitTestCase):
              {'adobe_reader': ['cache', 'mru', 'tmp']}),
             (['adobe_reader.mru'], [], {'adobe_reader': ['mru']}),
             (['adobe_reader.*'], ['adobe_reader.cache'],
-             {'adobe_reader': ['mru', 'tmp']}))
+             {'adobe_reader': ['mru', 'tmp']}),
+            (['adobe_reader.*', '-adobe_reader.cache'], [],
+             {'adobe_reader': ['mru', 'tmp']}),
+            # Leading '-' negation combined with an explicit --except (issue #2028)
+            (['adobe_reader.*', '-adobe_reader.mru'], ['adobe_reader.cache'],
+             {'adobe_reader': ['tmp']}),
+            # A negation that removes every option drops the cleaner entirely,
+            # rather than leaving a '-adobe_reader' key that later raises KeyError
+            (['adobe_reader.mru', '-adobe_reader.mru'], [], {}))
         for test_args, excludes, expected in tests:
             o = args_to_operations(test_args, False, False, excludes)
             self.assertIsInstance(o, dict)

--- a/tests/TestCLI.py
+++ b/tests/TestCLI.py
@@ -114,6 +114,11 @@ class CLITestCase(common.BleachbitTestCase):
                 ['adobe_reader.mru'], False, False, ['adobe_reader.*'])
         self.assertEqual(cm.exception.code, 1)
 
+        excludes = ['adobe_reader.cache']
+        args_to_operations(
+            ['adobe_reader.*', '-adobe_reader.mru'], False, False, excludes)
+        self.assertEqual(excludes, ['adobe_reader.cache'])
+
     def test_parse_cmd_line_except(self):
         """Unit test for parse_cmd_line() --except handling"""
         tests = (


### PR DESCRIPTION
## Summary

Fixes #2028. Excluding a cleaner from the command line with the `-` negation prefix (e.g. `system.* -system.recycle_bin`) crashed with a `KeyError` instead of excluding the option.

The argument `-system.recycle_bin` was being parsed as a cleaner literally named `-system` with option `recycle_bin`, producing an operations dict like `{'-system': ['recycle_bin'], ...}`. That bogus key later reached `Worker.run_operations`, where `backends['-system']` raised `KeyError` and dumped a traceback.

## Reproduction (before)

```
bleachbit_console.exe --preview -- system.* -system.recycle_bin
```

Intent: clean all system options *except* the Recycle Bin. Result: `KeyError` traceback, no cleaning.

## Fix

In `args_to_operations` (`bleachbit/CLI.py`), arguments beginning with `-` are now stripped of the prefix and routed into the same exclusion path already used by `--except`. So `system.*` is expanded first, then `-system.recycle_bin` removes the Recycle Bin option. If a negation removes a cleaner's last remaining option, the cleaner key is dropped entirely rather than left as an empty/stale entry.

The caller's `excludes` list is copied before appending so negations don't mutate it.

## Tests

Added cases to `test_args_to_operations` in `tests/TestCLI.py`:
- `-cleaner.option` negation removes the option
- Leading-`-` negation combined with an explicit `--except`
- A negation that removes a cleaner's last option drops the cleaner key (guards against the `KeyError`)

All `args_to_operations` / `--except` tests pass. The only failing test in the suite, `test_gui_exit`, fails identically on the base branch and is unrelated (GUI/environment).

## Notes

- Docstring for `args_to_operations` updated to document the negation syntax.
- On the command line, `-cleaner.option` args must follow `--` (as in the issue's example) so optparse treats them as positional arguments rather than options.

