### PR TITLE
Cancel the pending options flush before tearDown removes the file

### DIFF
--- a/tests/TestCommon.py
+++ b/tests/TestCommon.py
@@ -11,8 +11,11 @@ Test case for Common
 
 # standard imports
 import os
+from unittest import mock
 
 # first party imports
+import bleachbit
+import bleachbit.Options
 from tests import common
 
 
@@ -206,3 +209,43 @@ class CommonTestCase(common.BleachbitTestCase):
         os.remove(relative_fn)
         self.assertNotExists(relative_fn)
         self.assertNotExists('this-does-not-exist')
+
+    def test_teardown_cancels_flush_before_removing_options_file(self):
+        """Unit test for tearDown stopping the delayed flush first
+
+        The delayed flush writes bleachbit.ini from a daemon timer thread.
+        On Windows an open write handle makes os.remove() fail with
+        WinError 32, so tearDown must cancel the flush before it touches
+        the file.
+        """
+        options = bleachbit.Options.options
+
+        # Recreate what a test that writes an option leaves behind: the
+        # options file exists on disk and a fresh delayed flush is pending.
+        self._options_file_snapshot = None
+        options.set('check_online_updates',
+                    not options.get('check_online_updates'))
+        options.commit()
+        self.assertExists(bleachbit.options_file)
+        options.set('check_online_updates',
+                    not options.get('check_online_updates'))
+        self.assertIsNotNone(options._flush_timer,
+                             'precondition: a delayed flush is pending')
+
+        pending_at_remove = []
+        real_remove = os.remove
+
+        def recording_remove(path, *args, **kwargs):
+            if os.path.abspath(path) == os.path.abspath(bleachbit.options_file):
+                pending_at_remove.append(options._flush_timer)
+            return real_remove(path, *args, **kwargs)
+
+        with mock.patch('os.remove', side_effect=recording_remove):
+            self.tearDown()
+
+        self.assertEqual(len(pending_at_remove), 1,
+                         'tearDown did not remove the options file')
+        self.assertIsNone(pending_at_remove[0],
+                          'a delayed flush was still armed while tearDown '
+                          'removed the options file, which races the timer '
+                          'thread and raises WinError 32 on Windows')

--- a/tests/common.py
+++ b/tests/common.py
@@ -314,6 +314,10 @@ class BleachbitTestCase(unittest.TestCase):
         # WinError 32 in rmtree() in tearDownClass.
         basedir = os.path.join(os.path.dirname(__file__), '..')
         os.chdir(basedir)
+        # Stop the delayed flush before touching the options file. It writes
+        # bleachbit.ini from a daemon timer thread, so on Windows an open
+        # write handle makes the os.remove() below fail with WinError 32.
+        bleachbit.Options.options.cancel_pending_flush()
         if self._options_file_snapshot is not None:
             os.makedirs(os.path.dirname(bleachbit.options_file), exist_ok=True)
             with open(bleachbit.options_file, 'wb') as f:


### PR DESCRIPTION
Closes #2257

## Symptom

`tearDown` fails intermittently on Windows with the archive already in a good state:

```
E           PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: '...\bleachbit.ini'
tests\common.py:322: PermissionError
```

It surfaced as `WinappTestCase::test_excludekey_reg`, but nothing about that test is special. `BaseTestCase.tearDown` is inherited by every test, so any test that writes an option can leave the suite in the state that fails, and which one loses the race is timing.

## Cause

`tearDown` removed the options file first and cancelled the delayed flush afterwards:

```python
elif os.path.exists(bleachbit.options_file):
    os.remove(bleachbit.options_file)
bleachbit.Options.options.restore()
bleachbit.Options.options.cancel_pending_flush()   # too late
```

`Options.__schedule_flush()` arms a `threading.Timer` for `FLUSH_DELAY_SECS` (15s) and `__flush_locked()` writes the file with `open(bleachbit.options_file, 'w', ...)` from that daemon thread. So between a test touching an option and `tearDown` deleting the file, a writer may still be scheduled. POSIX unlinks a file that has an open handle; Windows refuses, which is `WinError 32`.

The fix moves the cancel above the file handling. That also covers the snapshot-restore branch, which rewrites the same path and can collide the same way.

## Evidence

The 15-second window makes the real race rare, so I drove the documented sequence directly — make the file exist, arm a fresh flush, then do what `tearDown` does — with `FLUSH_DELAY_SECS` shortened so the window is reachable. 3000 iterations each way on Windows 11 / Python 3.13:

```
order=current  removes_attempted=3000  PermissionError_hits=35
first error: PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: '...\bleachbit.ini'

order=fixed    removes_attempted=3000  PermissionError_hits=0
no PermissionError observed
```

## Test

`test_teardown_cancels_flush_before_removing_options_file` asserts the invariant rather than trying to win a race: at the moment `tearDown` removes the options file, no flush timer may be armed. It is deterministic in both directions. Reverting only the `common.py` change:

```
E       AssertionError: <Timer(Thread-6, stopped daemon 3824)> is not None : a delayed flush was
        still armed while tearDown removed the options file, which races the timer thread and
        raises WinError 32 on Windows
FAILED tests/TestCommon.py::CommonTestCase::test_teardown_cancels_flush_before_removing_options_file
1 failed, 10 deselected in 0.19s
```

With the change in place:

```
tests/TestCommon.py ...........            11 passed, 73 subtests passed in 0.20s
tests/TestOptions.py TestInit.py TestGeneral.py TestCommon.py
                                           53 passed, 6 skipped, 86 subtests passed in 7.08s
tests/TestWinapp.py                        11 passed, 2 skipped, 3 subtests passed in 14.48s
```

## Deliberately unchanged

- `FLUSH_DELAY_SECS` and the delayed-flush design. The timer is a product feature; the test harness was simply deleting a file out from under it.
- The trailing `cancel_pending_flush()` call. `restore()` re-arms a timer when the file has no matching version, and the existing comment says so, so that call is still needed. This adds a cancel, it does not move one.
- `Options.__flush_locked()` still catches `PermissionError` and logs. Making the harness stop racing seemed better than making the product quieter about losing.

## Limitations

- I could not reproduce the failure through the real 15-second timer; the reproduction shortens `FLUSH_DELAY_SECS`. The ordering it exercises is the shipped ordering, but the timing is forced.
- I did not run the suite under `pytest-xdist`, which is how CI hit this. `xdist` is not installed here, so `TestWinapp.py` ran single-process and its `xdist_group` marks were reported as unknown. Each worker has its own options file and its own `Options` singleton, so the race is within a worker, not between them — but CI is the authority on the parallel run.
- The GTK-dependent tests skip on this machine, so the numbers above are a subset of the suite, not a full green run.
