### PR TITLE
nsis_translations.py: write NsisMultiUserLang.nsh with CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,8 +23,6 @@
 # Declare files that will always have CRLF line endings on checkout
 *.sln text eol=crlf
 *.bat text eol=crlf
-*.nsi text eol=crlf
-*.nsh text eol=crlf
 *.ini text eol=crlf
 
 # Denote all files that are truly binary and should not be modified

--- a/windows/nsis_translations.py
+++ b/windows/nsis_translations.py
@@ -370,7 +370,8 @@ def write_nsis_langfile():
                 f'\tLangString {key} ${{{lang_macro}}} "{_escape_nsis_text(text)}"\n')
         lines.append('!endif\n\n')
 
-    with open(OUTPUT_NSH, 'w', encoding='utf-8') as nsh_file:
+    # CRLF to match .gitattributes (*.nsh text eol=crlf)
+    with open(OUTPUT_NSH, 'w', encoding='utf-8', newline='\r\n') as nsh_file:
         nsh_file.write(''.join(lines))
 
 

--- a/windows/nsis_translations.py
+++ b/windows/nsis_translations.py
@@ -314,7 +314,7 @@ def write_nsis_pot():
         lines.append(f'msgid "{msgid}"\n')
         lines.append('msgstr ""\n\n')
 
-    with open(OUTPUT_POT, 'w', encoding='utf-8') as pot_file:
+    with open(OUTPUT_POT, 'w', encoding='utf-8', newline='\n') as pot_file:
         pot_file.write(''.join(lines))
 
 
@@ -370,8 +370,7 @@ def write_nsis_langfile():
                 f'\tLangString {key} ${{{lang_macro}}} "{_escape_nsis_text(text)}"\n')
         lines.append('!endif\n\n')
 
-    # CRLF to match .gitattributes (*.nsh text eol=crlf)
-    with open(OUTPUT_NSH, 'w', encoding='utf-8', newline='\r\n') as nsh_file:
+    with open(OUTPUT_NSH, 'w', encoding='utf-8', newline='\n') as nsh_file:
         nsh_file.write(''.join(lines))
 
 


### PR DESCRIPTION
Fixes a warning on CI

Makes me wonder if we really need CRLF for those, though. I'll test it with LF too, **do not merge yet**.