### PR TITLE
Makefile: run pyflake and pylint in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,12 +134,10 @@ lint:
 	else \
 		echo "WARNING: Missing shellcheck. APT users, try: sudo apt install shellcheck"; \
 	fi
-	for f in *py */*py; \
-	do \
-		echo "$$f"; \
-		( pyflakes3 "$$f" > "$$f".pyflakes.log ); \
-		( pylint "$$f" > "$$f".pylint.log ); \
-	done; \
+	@echo "Running pyflakes3 and pylint in parallel: see all.pyflakes.log and all.pylint.log"
+	@pyflakes3 *py */*py > all.pyflakes.log 2>&1 & \
+	pylint -j 0 *py */*py > all.pylint.log 2>&1 & \
+	wait; \
 	exit 0
 
 delete_windows_files:


### PR DESCRIPTION
This should cut the time down to a few seconds from minutes, at least on my dev Windows VM.

It introduces some new issues that pylint can catch now, though. I'll leave those to you @az0. Maybe disable some for now and tackle them later, your call.