### PR TITLE
Cleaners: add Android Studio and Gradle cache cleaner

### DIFF
--- a/cleaners/android_studio.xml
+++ b/cleaners/android_studio.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
 
+SPDX-License-Identifier: GPL-3.0-or-later
+Copyright (c) 2008-2026 Andrew Ziem.
+
+This work is licensed under the terms of the GNU GPL, version 3 or
+later.  See the COPYING file in the top-level directory.
+
+-->
 <cleaner id="android_studio">
   <label>Android Studio</label>
   <description>Integrated development environment for Google Android</description>

--- a/cleaners/android_studio.xml
+++ b/cleaners/android_studio.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+SPDX-License-Identifier: GPL-3.0-or-later
+Copyright (c) 2008-2026 Andrew Ziem.
+
+This work is licensed under the terms of the GNU GPL, version 3 or
+later.  See the COPYING file in the top-level directory.
+
+-->
+<cleaner id="android_studio">
+  <label>Android Studio</label>
+  <description>Integrated development environment for Google Android</description>
+  
+  <running type="exe" os="unix" same_user="true">studio.sh</running>
+  <running type="exe" os="windows" same_user="true">studio.exe</running>
+  <running type="exe" os="windows" same_user="true">studio64.exe</running>
+  <running type="exe" os="macos" same_user="true">studio</running>
+
+  <var name="gradle_home">
+    <value os="windows">%UserProfile%\.gradle</value>
+    <value os="macos">~/.gradle</value>
+    <value os="unix">~/.gradle</value>
+  </var>
+
+  <var name="android_home">
+    <value os="windows">%UserProfile%\.android</value>
+    <value os="macos">~/.android</value>
+    <value os="unix">~/.android</value>
+  </var>
+
+  <var name="as_cache">
+    <value search="glob" os="windows">%LocalAppData%\Google\AndroidStudio*\caches</value>
+    <value search="glob" os="macos">~/Library/Caches/Google/AndroidStudio*</value>
+    <value search="glob" os="unix">~/.cache/Google/AndroidStudio*</value>
+  </var>
+
+  <var name="as_logs">
+    <value search="glob" os="windows">%LocalAppData%\Google\AndroidStudio*\log</value>
+    <value search="glob" os="macos">~/Library/Logs/Google/AndroidStudio*</value>
+    <value search="glob" os="unix">~/.cache/Google/AndroidStudio*/log</value>
+    <value search="glob" os="unix">~/.config/Google/AndroidStudio*/log</value>
+  </var>
+
+  <option id="gradle_cache">
+    <label>Gradle cache</label>
+    <description>Delete downloaded dependencies and build artifacts</description>
+    <warning>Deleting the Gradle cache will require dependencies to be redownloaded on the next build.</warning>
+    <action command="delete" search="walk.all" path="$$gradle_home$$/caches/"/>
+    <action command="delete" search="walk.all" path="$$gradle_home$$/daemon/"/>
+  </option>
+
+  <option id="cache">
+    <label>Cache</label>
+    <description>Delete IDE caches and Android build cache</description>
+    <action command="delete" search="walk.all" path="$$android_home$$/cache/"/>
+    <action command="delete" search="walk.all" path="$$android_home$$/build-cache/"/>
+    <action command="delete" search="walk.all" path="$$as_cache$$"/>
+  </option>
+
+  <option id="logs">
+    <label>Logs</label>
+    <description>Delete log files and crash dumps</description>
+    <action command="delete" search="glob" path="$$as_logs$$/*.log*"/>
+    <action command="delete" search="glob" path="$$as_logs$$/threadDumps*"/>
+  </option>
+</cleaner>

--- a/cleaners/android_studio.xml
+++ b/cleaners/android_studio.xml
@@ -32,14 +32,13 @@ later.  See the COPYING file in the top-level directory.
   <var name="as_cache">
     <value search="glob" os="windows">%LocalAppData%\Google\AndroidStudio*\caches</value>
     <value search="glob" os="macos">~/Library/Caches/Google/AndroidStudio*</value>
-    <value search="glob" os="unix">~/.cache/Google/AndroidStudio*</value>
+    <value search="glob" os="unix">~/.cache/Google/AndroidStudio*/caches</value>
   </var>
 
   <var name="as_logs">
     <value search="glob" os="windows">%LocalAppData%\Google\AndroidStudio*\log</value>
     <value search="glob" os="macos">~/Library/Logs/Google/AndroidStudio*</value>
     <value search="glob" os="unix">~/.cache/Google/AndroidStudio*/log</value>
-    <value search="glob" os="unix">~/.config/Google/AndroidStudio*/log</value>
   </var>
 
   <option id="gradle_cache">

--- a/cleaners/android_studio.xml
+++ b/cleaners/android_studio.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
 
-SPDX-License-Identifier: GPL-3.0-or-later
-Copyright (c) 2008-2026 Andrew Ziem.
-
-This work is licensed under the terms of the GNU GPL, version 3 or
-later.  See the COPYING file in the top-level directory.
-
--->
 <cleaner id="android_studio">
   <label>Android Studio</label>
   <description>Integrated development environment for Google Android</description>


### PR DESCRIPTION
Adds a new cleaner for Android Studio and Gradle build/dependency caches across Windows, macOS, and Linux.

### Options:
- **Gradle cache**: Deletes `~/.gradle/caches/` and `~/.gradle/daemon/`.
- **Cache**: Deletes `~/.android/cache/`, `~/.android/build-cache/`, and Android Studio IDE caches.
- **Logs**: Deletes Android Studio log files and thread dumps.

### Testing:
- Validated against `doc/cleaner_markup_language.xsd`.
- Verified preview locally.