### PR TITLE
Unix.py: fix get_trash_paths() leaving emptied folders behind in ~/.T…

### DIFF
--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -426,9 +426,12 @@ def get_trash_paths():
     # Import here to avoid a circular import.
     # pylint: disable=import-outside-toplevel
     from bleachbit import Command
-    # macOS-style flat trash (non-recursive)
+    # macOS-style flat trash. list_directories=True is required so that
+    # a folder sent to Trash is itself removed after its contents are
+    # deleted; with False, only files inside it are yielded and the now-
+    # empty folder is left behind forever.
     dirname = os.path.expanduser("~/.Trash")
-    for filename in children_in_directory(dirname, False):
+    for filename in children_in_directory(dirname, True):
         yield Command.Delete(filename)
     # Freedesktop trash spec directories
     # https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -363,6 +363,38 @@ PrefersNonDefaultGPU=false""")
         self.assertEqual(len(seen), len(
             set(p.path for p in seen)), "Duplicate trash paths found")
 
+    def test_get_trash_paths_includes_now_empty_folder(self):
+        """Regression test: a folder sent to the macOS Trash must be
+        yielded for deletion itself, not just the files inside it.
+
+        get_trash_paths() previously called
+        children_in_directory(dirname, False), where the second argument
+        is list_directories, not 'recursive' as an earlier comment
+        claimed. With False, only files are yielded and a folder emptied
+        by this same cleaning pass is left behind forever, empty, in
+        ~/.Trash.
+        """
+        trash_dir = self.mkdtemp(prefix='bleachbit-test-trash')
+        sub_dir = os.path.join(trash_dir, 'folder-in-trash')
+        os.mkdir(sub_dir)
+        file_path = os.path.join(sub_dir, 'file.txt')
+        self.write_file(file_path)
+
+        real_expanduser = os.path.expanduser
+
+        def fake_expanduser(p):
+            if p == '~/.Trash':
+                return trash_dir
+            return real_expanduser(p)
+
+        with mock.patch('os.path.expanduser', side_effect=fake_expanduser):
+            paths = [p.path for p in get_trash_paths()]
+
+        self.assertIn(file_path, paths)
+        self.assertIn(
+            sub_dir, paths,
+            'the emptied folder itself must also be yielded for deletion')
+
     @common.skipIfWindows
     def test_desktop_valid_exe(self):
         """Unit test for .desktop file with valid Unix exe (not env)"""

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -363,6 +363,7 @@ PrefersNonDefaultGPU=false""")
         self.assertEqual(len(seen), len(
             set(p.path for p in seen)), "Duplicate trash paths found")
 
+    @common.skipIfWindows
     def test_get_trash_paths_includes_now_empty_folder(self):
         """Regression test: a folder sent to the macOS Trash must be
         yielded for deletion itself, not just the files inside it.


### PR DESCRIPTION
…rash

get_trash_paths() called children_in_directory(dirname, False) for the macOS-style flat trash, under a comment claiming this made the scan 'non-recursive'. The second parameter is actually list_directories, not a recursion toggle: children_in_directory() always recurses into subdirectories regardless of its value: with False it yields only files, descending into folders without ever yielding the folders themselves for deletion.

The practical effect: sending a folder to the Trash and then running BleachBit's 'Trash' cleaner deleted every file inside it but left the now-empty folder behind permanently, since it was never yielded as something to delete. This matches an existing docstring in FileUtilities.py: 'When list_directories is set, every directory found ... is collected into pending_dirs to be emitted after its contents' -- i.e. folders are only ever yielded when list_directories=True.

Reproduced with a real ~/.Trash folder before fixing: BleachBit reported deleting the file inside successfully, but the containing folder remained afterward, with a follow-up preview correctly showing 0 files left (nothing inside it), while the empty folder itself stayed in the Trash indefinitely.

tests/TestUnix.py adds
test_get_trash_paths_includes_now_empty_folder, using a temp directory mocked in place of ~/.Trash for a controlled, deterministic regression test; confirmed to fail against the pre-fix code (the folder path missing from the yielded paths) before being finalized.