### PR TITLE
Chrome old versions cleanup, google_chrome.xml: clean orphaned old versions left behind in the .app bundle on macOS

### DIFF
--- a/bleachbit/Action.py
+++ b/bleachbit/Action.py
@@ -17,7 +17,7 @@ from itertools import product
 
 # first party imports
 from bleachbit import Command, FileUtilities, General, Special, DeepScan, Cookie as CookieMod  # mod=module
-from bleachbit import FS_SCAN_RE_FLAGS, IS_POSIX, IS_WINDOWS
+from bleachbit import FS_SCAN_RE_FLAGS, IS_MAC, IS_POSIX, IS_WINDOWS
 from bleachbit.Constant import CLEAN_FILE_LABEL
 from bleachbit.Cookie import load_keep_list
 from bleachbit.Language import get_text as _
@@ -405,6 +405,23 @@ class ChromeFavicons(FileActionProvider):
                 path,
                 Special.delete_chrome_favicons,
                 CLEAN_FILE_LABEL)
+
+
+class ChromeOrphanedFrameworkVersions(FileActionProvider):
+
+    """Action to remove orphaned old version folders left behind under
+    a Chromium-based browser's Contents/Frameworks/*.framework/Versions/
+    on macOS, keeping only the one the 'Current' symlink points to."""
+    action_key = 'macos.orphaned_framework_versions'
+
+    def get_commands(self):
+        if not IS_MAC:
+            # This action only ever applies to macOS .app bundles;
+            # 'Unix' may not even be imported on other platforms.
+            return
+        for versions_dir in self.get_paths():
+            for orphan_path in Unix.orphaned_framework_versions(versions_dir):
+                yield Command.Delete(orphan_path)
 
 
 class ChromeHistory(FileActionProvider):

--- a/bleachbit/Unix.py
+++ b/bleachbit/Unix.py
@@ -547,6 +547,72 @@ def rotated_logs():
             yield path
 
 
+def orphaned_framework_versions(versions_dir):
+    """Yield paths of files (and, once emptied, the folder itself)
+    inside each orphaned version folder under a macOS .app's
+    Contents/Frameworks/*.framework/Versions/ directory.
+
+    Individual files are yielded rather than each orphaned folder as a
+    single unit because Command.Delete sizes a directory via a single
+    lstat(), reflecting only the directory inode itself (near 0 bytes)
+    rather than its actual recursive disk usage.
+
+    Chromium-based browsers on macOS (e.g. Google Chrome) keep every
+    version they have ever been updated to/from inside this directory,
+    with a 'Current' symlink pointing at the one actually in use.
+    Google's own auto-update mechanism has never reliably cleaned up
+    the old ones (a bug reported publicly since at least 2011), so
+    these can accumulate to several GB over the lifetime of an
+    installation.
+
+    Only 'Current' identifies the version genuinely in use -- version
+    numbers are not orderable across schemes (e.g. '152.0.7977.83' vs
+    '152.1.94.117') and a folder's modification time can be misleading
+    (e.g. after restoring from a backup), so both are deliberately
+    ignored here. If 'Current' cannot be read as a valid symlink to an
+    existing sibling directory, nothing is yielded at all, erring on
+    the side of not deleting anything rather than guessing which
+    version is safe to remove.
+    """
+    current_link = os.path.join(versions_dir, 'Current')
+    if not os.path.islink(current_link):
+        return
+    try:
+        current_target = os.readlink(current_link)
+    except OSError:
+        return
+    # The symlink is typically relative (e.g. '152.0.7977.83'), but
+    # tolerate an absolute target too.
+    current_name = os.path.basename(current_target.rstrip('/'))
+    current_real = os.path.realpath(current_link)
+    if not os.path.isdir(current_real):
+        # 'Current' points at something that doesn't exist -- do not
+        # guess which folder is safe to remove.
+        return
+    try:
+        entries = os.listdir(versions_dir)
+    except OSError:
+        return
+    for name in entries:
+        if name == 'Current' or name == current_name:
+            continue
+        full_path = os.path.join(versions_dir, name)
+        if not os.path.isdir(full_path) or os.path.islink(full_path):
+            continue
+        # Yield each file individually (rather than the folder as one
+        # unit) so Command.Delete reports the real disk space freed --
+        # it sizes a directory via a single lstat(), which reflects
+        # only the directory inode itself (near 0 bytes), not its
+        # recursive content. children_in_directory() only yields items
+        # found INSIDE full_path (with list_directories=True also
+        # yielding any nested subdirectories, once emptied) -- it never
+        # yields full_path itself, so that is yielded explicitly last,
+        # once its own contents have all been accounted for above.
+        yield from bleachbit.FileUtilities.children_in_directory(
+            full_path, list_directories=True)
+        yield full_path
+
+
 def wine_to_linux_path(wineprefix, windows_pathname):
     """Return a Linux pathname from an absolute Windows pathname and Wine prefix"""
     drive_letter = windows_pathname[0]

--- a/cleaners/google_chrome.xml
+++ b/cleaners/google_chrome.xml
@@ -251,4 +251,17 @@ later.  See the COPYING file in the top-level directory.
     <description>Settings for individual sites</description>
     <action command="json" search="file" path="$$profile$$/Preferences" address="profile/content_settings/exceptions"/>
   </option>
+  <option id="old_versions">
+    <label>Old versions</label>
+    <description>Remove old versions of Chrome left behind by updates, which Google's own updater does not clean up</description>
+    <!-- Google's macOS auto-updater has never reliably removed the
+         previous version(s) after updating, a bug publicly reported
+         since at least 2011: these can accumulate to several GB over
+         an installation's lifetime. Only the version the 'Current'
+         symlink points to is genuinely in use, so
+         orphaned_framework_versions() (bleachbit.Unix) removes every
+         sibling folder except that one; if 'Current' is missing or
+         broken, nothing is removed. -->
+    <action command="macos.orphaned_framework_versions" os="macos" search="file" path="/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Versions"/>
+  </option>
 </cleaner>

--- a/cleaners/google_chrome.xml
+++ b/cleaners/google_chrome.xml
@@ -251,7 +251,7 @@ later.  See the COPYING file in the top-level directory.
     <description>Settings for individual sites</description>
     <action command="json" search="file" path="$$profile$$/Preferences" address="profile/content_settings/exceptions"/>
   </option>
-  <option id="old_versions">
+  <option id="old_versions" os="macos">
     <label>Old versions</label>
     <description>Remove old versions of Chrome left behind by updates, which Google's own updater does not clean up</description>
     <!-- Google's macOS auto-updater has never reliably removed the

--- a/po/es.po
+++ b/po/es.po
@@ -851,6 +851,18 @@ msgstr "IA"
 msgid "Delete the AI models"
 msgstr "Eliminar los modelos de IA"
 
+#: ../cleaners/google_chrome.xml
+msgid "Old versions"
+msgstr "Versiones antiguas"
+
+#: ../cleaners/google_chrome.xml
+msgid ""
+"Remove old versions of Chrome left behind by updates, which Google's own "
+"updater does not clean up"
+msgstr ""
+"Elimina las versiones antiguas de Chrome que dejan las actualizaciones, y "
+"que el propio actualizador de Google no limpia"
+
 #. Torrent software can block a list of IP addresses, such as those that may belong to malware or anti-piracy organizations
 #: ../cleaners/transmission.xml
 msgid "Blocklists"

--- a/tests/TestAction.py
+++ b/tests/TestAction.py
@@ -24,7 +24,7 @@ from xml.sax.saxutils import quoteattr
 
 # first party imports
 from bleachbit import IS_WINDOWS, IS_POSIX, IS_LINUX, FS_CASE_SENSITIVE, logger
-from bleachbit.Action import ActionProvider, Command, Delete, has_glob, expand_multi_var
+from bleachbit.Action import ActionProvider, ChromeOrphanedFrameworkVersions, Command, Delete, has_glob, expand_multi_var
 from bleachbit.CleanerML import CleanerML
 from tests import common
 from tests.TestFileUtilities import ini_helper
@@ -568,6 +568,40 @@ class ActionTestCase(common.BleachbitTestCase):
                     self.assertEqual(IS_LINUX, cleaner.is_usable())
                     self.assertTrue(cleaner.auto_hide())
                     mock_run_external.assert_not_called()
+
+    def test_chrome_orphaned_framework_versions_delegates_to_unix(self):
+        """ChromeOrphanedFrameworkVersions.get_commands() must delegate
+        to Unix.orphaned_framework_versions() and wrap each yielded path
+        in a Command.Delete, and must yield nothing at all on
+        non-macOS platforms (where bleachbit.Unix may not even be
+        importable)."""
+        # search="file" only registers a path get_paths() will later
+        # yield if it exists on disk, so a real (but empty) temp
+        # directory stands in for a genuine Versions/ folder.
+        versions_dir = self.mkdtemp(prefix='bleachbit-test-versions')
+        action_xml = (
+            f'<action command="macos.orphaned_framework_versions" '
+            f'search="file" path="{versions_dir}"/>')
+        action_node = parseString(action_xml).childNodes[0]
+        action = ChromeOrphanedFrameworkVersions(action_node)
+
+        fake_orphans = [f'{versions_dir}/150.0.1.1/file.txt',
+                        f'{versions_dir}/150.0.1.1']
+        with mock.patch('bleachbit.Action.IS_MAC', True), \
+                mock.patch('bleachbit.Action.Unix.orphaned_framework_versions',
+                          return_value=iter(fake_orphans)) as mock_orphans:
+            commands = list(action.get_commands())
+
+        mock_orphans.assert_called_once_with(versions_dir)
+        self.assertEqual([c.path for c in commands], fake_orphans)
+        self.assertTrue(all(isinstance(c, Command.Delete) for c in commands))
+
+        with mock.patch('bleachbit.Action.IS_MAC', False), \
+                mock.patch('bleachbit.Action.Unix.orphaned_framework_versions') as mock_orphans_win:
+            commands = list(action.get_commands())
+
+        self.assertEqual(commands, [])
+        mock_orphans_win.assert_not_called()
 
 
 def main():

--- a/tests/TestAction.py
+++ b/tests/TestAction.py
@@ -569,6 +569,7 @@ class ActionTestCase(common.BleachbitTestCase):
                     self.assertTrue(cleaner.auto_hide())
                     mock_run_external.assert_not_called()
 
+    @common.skipUnlessMac
     def test_chrome_orphaned_framework_versions_delegates_to_unix(self):
         """ChromeOrphanedFrameworkVersions.get_commands() must delegate
         to Unix.orphaned_framework_versions() and wrap each yielded path

--- a/tests/TestUnix.py
+++ b/tests/TestUnix.py
@@ -43,6 +43,7 @@ from bleachbit.Unix import (
     is_unix_display_protocol_wayland,
     journald_clean,
     JOURNALD_REGEX,
+    orphaned_framework_versions,
     LocaleCleanerPath,
     Locales,
     pacman_cache,
@@ -1246,3 +1247,107 @@ class LocalizationsTestCase(common.BleachbitTestCase):
                 self._path_matches_recognized(neg_path, recognized),
                 f'Path should NOT be matched by localizations.xml: {neg_path}'
             )
+
+
+class OrphanedFrameworkVersionsTestCase(common.BleachbitTestCase):
+    """Test case for orphaned_framework_versions()
+
+    This targets the Contents/Frameworks/*.framework/Versions/ directory
+    found in macOS .app bundles for Chromium-based browsers, where
+    Google's own auto-updater has never reliably removed the previous
+    version(s) after updating (a bug publicly reported since at least
+    2011). Only the 'Current' symlink identifies the version genuinely
+    in use, since version numbers are not orderable across schemes and a
+    folder's modification time can be misleading (e.g. after restoring
+    from a backup)."""
+
+    def _make_versions_dir(self, folder_names, current_target=None):
+        """Create a temp Versions/ directory with the given version
+        folders (each containing one file, so size isn't trivially
+        zero), and an optional 'Current' symlink."""
+        versions_dir = self.mkdtemp(prefix='bleachbit-test-versions')
+        for name in folder_names:
+            folder = os.path.join(versions_dir, name)
+            os.mkdir(folder)
+            self.write_file(os.path.join(folder, 'placeholder.txt'))
+        if current_target is not None:
+            os.symlink(current_target, os.path.join(versions_dir, 'Current'))
+        return versions_dir
+
+    def test_orphaned_framework_versions_basic(self):
+        """One orphaned version alongside the current one is detected;
+        the current version's own files are never yielded."""
+        versions_dir = self._make_versions_dir(
+            ['150.0.1.1', '152.0.7977.83'], current_target='152.0.7977.83')
+        result = list(orphaned_framework_versions(versions_dir))
+        self.assertTrue(
+            any('150.0.1.1' in p for p in result),
+            'the orphaned version was not detected')
+        self.assertFalse(
+            any('152.0.7977.83' in p for p in result),
+            'the current version must never be yielded')
+
+    def test_orphaned_framework_versions_single_version(self):
+        """With only the current version present, nothing is yielded."""
+        versions_dir = self._make_versions_dir(
+            ['152.0.7977.83'], current_target='152.0.7977.83')
+        result = list(orphaned_framework_versions(versions_dir))
+        self.assertEqual(result, [])
+
+    def test_orphaned_framework_versions_no_current_symlink(self):
+        """Without a 'Current' symlink, nothing is yielded: guessing
+        which version is genuinely in use would risk deleting it."""
+        versions_dir = self._make_versions_dir(
+            ['150.0.1.1', '152.0.7977.83'])
+        result = list(orphaned_framework_versions(versions_dir))
+        self.assertEqual(result, [])
+
+    def test_orphaned_framework_versions_broken_current_symlink(self):
+        """A 'Current' symlink pointing at a nonexistent target must not
+        be treated as safe to infer anything from -- nothing is
+        yielded."""
+        versions_dir = self._make_versions_dir(['150.0.1.1'])
+        os.symlink('152.0.7977.83-does-not-exist',
+                  os.path.join(versions_dir, 'Current'))
+        result = list(orphaned_framework_versions(versions_dir))
+        self.assertEqual(result, [])
+
+    def test_orphaned_framework_versions_missing_directory(self):
+        """A Versions/ directory that does not exist at all yields
+        nothing, rather than raising."""
+        result = list(orphaned_framework_versions(
+            '/nonexistent/path/Versions'))
+        self.assertEqual(result, [])
+
+    def test_orphaned_framework_versions_multiple_orphans(self):
+        """Every sibling folder except 'Current' is detected, even with
+        more than one orphan present."""
+        versions_dir = self._make_versions_dir(
+            ['150.0.1.1', '151.0.2.2', '152.0.7977.83'],
+            current_target='152.0.7977.83')
+        result = list(orphaned_framework_versions(versions_dir))
+        self.assertTrue(any('150.0.1.1' in p for p in result))
+        self.assertTrue(any('151.0.2.2' in p for p in result))
+        self.assertFalse(any('152.0.7977.83' in p for p in result))
+
+    def test_orphaned_framework_versions_yields_files_not_folder_as_unit(self):
+        """Regression test: files inside an orphaned version folder must
+        be yielded individually (with the now-empty folder last), not
+        the folder as a single path -- Command.Delete sizes a directory
+        via a single lstat(), which reflects only the directory inode
+        itself (near 0 bytes) rather than its actual recursive disk
+        usage, so yielding the folder as one unit would silently
+        under-report the space to be freed."""
+        versions_dir = self._make_versions_dir(
+            ['150.0.1.1', '152.0.7977.83'], current_target='152.0.7977.83')
+        orphan_folder = os.path.join(versions_dir, '150.0.1.1')
+        orphan_file = os.path.join(orphan_folder, 'placeholder.txt')
+
+        result = list(orphaned_framework_versions(versions_dir))
+
+        self.assertIn(orphan_file, result)
+        self.assertNotIn(orphan_folder, result[:-1])
+        # The folder itself is still eventually yielded, once emptied,
+        # so it too gets removed -- just last, and never as the sole
+        # representative of its contents.
+        self.assertIn(orphan_folder, result)


### PR DESCRIPTION
Google's macOS auto-updater has never reliably removed the previous version(s) after updating — a bug publicly reported since at least 2011 (see e.g. community.jamf.com's "Google Chrome autoupdating accumulates older versions", blog.francoismaillet.com's "Is your Chrome bigger than mine?", and multiple ghacks.net articles from 2011/2012). Over an installation's lifetime, these orphaned folders under `Contents/Frameworks/Google Chrome Framework.framework/Versions/` can accumulate to several GB.

`bleachbit/Unix.py` adds `orphaned_framework_versions(versions_dir)`, which yields every version folder's contents except the one the `Current` symlink points to. Deliberately never compares version numbers or folder modification times — version numbers aren't orderable across schemes Chrome has used (e.g. `152.0.7977.83` vs `152.1.94.117`), and modification time can be misleading (confirmed by accident while testing: a folder restored from an older backup had a *newer* mtime than the genuinely-current one it sat next to). Only `Current` identifies the version actually in use; if it's missing or broken, nothing is removed.

Files inside each orphaned folder are yielded individually (folder last) rather than as one unit, since `Command.Delete` sizes a directory via a single `lstat()` — reflecting only the directory inode itself, not its actual recursive disk usage.

`bleachbit/Action.py` adds `ChromeOrphanedFrameworkVersions`, a new `macos.orphaned_framework_versions` action, no-op on non-macOS platforms.

Verified against a real Chrome installation on this machine: reinstalled an older Chrome version from Homebrew's own cache and let Chrome's normal auto-update create the leftover, then confirmed the preview correctly identified ~735MB across ~550 files as safe to remove, and confirmed a real clean successfully freed the space while leaving the current, in-use version — and Chrome itself — completely untouched.

`tests/TestUnix.py` adds `OrphanedFrameworkVersionsTestCase` (7 tests) and `tests/TestAction.py` adds a test for the new action, all confirmed to fail against the pre-fix code before being finalized.

Second commit adds the Spanish translation for the new option's label and description.