### PR TITLE
bleachbit/__init__.py: fix locale directory resolution in macOS .app …

### DIFF
--- a/bleachbit/__init__.py
+++ b/bleachbit/__init__.py
@@ -259,25 +259,46 @@ for __icon in __icons:
     if os.path.exists(__icon):
         appicon_path = __icon
 
+def _resolve_locale_dir(exe_path, is_linux, is_mac, is_windows, is_netbsd, is_bsd,
+                        path_exists=os.path.exists):
+    """Return the locale directory to use, given the platform and the
+    directory containing the running executable.
+
+    In the macOS .app bundle, exe_path is Contents/Resources (the parent
+    of the bleachbit package directory), while locale/ lives one level up
+    at Contents/locale -- neither the './locale/' nor the AppImage-style
+    'next to the executable' check below finds it, which previously fell
+    through to the Linux/macOS '/usr/share/locale/' fallback and silently
+    lost all bundled translations.
+    """
+    exe_locale_dir = os.path.join(exe_path, 'locale')
+    bundle_locale_dir = os.path.normpath(
+        os.path.join(exe_path, '..', 'locale')) if is_mac else None
+    if path_exists("./locale/"):
+        # local locale (personal)
+        return os.path.abspath("./locale/")
+    if path_exists(exe_locale_dir):
+        # AppImage
+        return exe_locale_dir
+    if is_mac and bundle_locale_dir and path_exists(bundle_locale_dir):
+        # macOS .app bundle: Contents/locale, one level above
+        # Contents/Resources
+        return bundle_locale_dir
+    # system-wide installed locale
+    if is_linux or is_mac:
+        return "/usr/share/locale/"
+    if is_windows:
+        return os.path.join(exe_path, "share\\locale\\")
+    if is_netbsd:
+        return "/usr/pkg/share/locale/"
+    if is_bsd:
+        return "/usr/local/share/locale/"
+    return "/usr/share/locale/"
+
+
 # locale directory
-_exe_locale_dir = os.path.join(bleachbit_exe_path, 'locale')
-if os.path.exists("./locale/"):
-    # local locale (personal)
-    locale_dir = os.path.abspath("./locale/")
-elif os.path.exists(_exe_locale_dir):
-    # AppImage
-    locale_dir = _exe_locale_dir
-# system-wide installed locale
-elif IS_LINUX or IS_MAC:
-    locale_dir = "/usr/share/locale/"
-elif IS_WINDOWS:
-    locale_dir = os.path.join(bleachbit_exe_path, "share\\locale\\")
-elif IS_NETBSD:
-    locale_dir = "/usr/pkg/share/locale/"
-elif IS_BSD:
-    locale_dir = "/usr/local/share/locale/"
-else:
-    locale_dir = "/usr/share/locale/"
+locale_dir = _resolve_locale_dir(
+    bleachbit_exe_path, IS_LINUX, IS_MAC, IS_WINDOWS, IS_NETBSD, IS_BSD)
 
 
 #

--- a/tests/TestCommon.py
+++ b/tests/TestCommon.py
@@ -239,3 +239,53 @@ class CommonTestCase(common.BleachbitTestCase):
         os.remove(relative_fn)
         self.assertNotExists(relative_fn)
         self.assertNotExists('this-does-not-exist')
+
+
+class ResolveLocaleDirTestCase(common.BleachbitTestCase):
+    """Test case for bleachbit._resolve_locale_dir()"""
+
+    def test_macos_app_bundle(self):
+        """On macOS, prefer Contents/locale (one level above
+        Contents/Resources) over the generic /usr/share/locale/
+        fallback, when it exists."""
+        from bleachbit import _resolve_locale_dir
+        exe_path = '/Applications/BleachBit.app/Contents/Resources'
+        bundle_dir = '/Applications/BleachBit.app/Contents/locale'
+        result = _resolve_locale_dir(
+            exe_path, is_linux=False, is_mac=True, is_windows=False,
+            is_netbsd=False, is_bsd=False,
+            path_exists=lambda p: p == bundle_dir)
+        self.assertEqual(result, bundle_dir)
+
+    def test_macos_no_bundle_falls_back(self):
+        """On macOS, when neither the local, AppImage-style, nor
+        bundle-relative locale directory exists, fall back to the
+        generic system path."""
+        from bleachbit import _resolve_locale_dir
+        result = _resolve_locale_dir(
+            '/some/dev/path', is_linux=False, is_mac=True,
+            is_windows=False, is_netbsd=False, is_bsd=False,
+            path_exists=lambda p: False)
+        self.assertEqual(result, '/usr/share/locale/')
+
+    def test_local_locale_takes_priority(self):
+        """A local ./locale/ directory (running from source) takes
+        priority over the macOS bundle path, even on macOS."""
+        from bleachbit import _resolve_locale_dir
+        result = _resolve_locale_dir(
+            '/Applications/BleachBit.app/Contents/Resources',
+            is_linux=False, is_mac=True, is_windows=False,
+            is_netbsd=False, is_bsd=False,
+            path_exists=lambda p: p == './locale/')
+        self.assertTrue(result.endswith('locale'))
+        self.assertNotIn('BleachBit.app', result)
+
+    def test_non_mac_unaffected(self):
+        """On Linux, the macOS bundle-relative check must never be
+        consulted, even if such a path happened to exist."""
+        from bleachbit import _resolve_locale_dir
+        result = _resolve_locale_dir(
+            '/usr/bin', is_linux=True, is_mac=False, is_windows=False,
+            is_netbsd=False, is_bsd=False,
+            path_exists=lambda p: False)
+        self.assertEqual(result, '/usr/share/locale/')

--- a/tests/TestCommon.py
+++ b/tests/TestCommon.py
@@ -250,7 +250,7 @@ class ResolveLocaleDirTestCase(common.BleachbitTestCase):
         fallback, when it exists."""
         from bleachbit import _resolve_locale_dir
         exe_path = '/Applications/BleachBit.app/Contents/Resources'
-        bundle_dir = '/Applications/BleachBit.app/Contents/locale'
+        bundle_dir = os.path.normpath(os.path.join(exe_path, '..', 'locale'))
         result = _resolve_locale_dir(
             exe_path, is_linux=False, is_mac=True, is_windows=False,
             is_netbsd=False, is_bsd=False,


### PR DESCRIPTION
…bundle

The packaged macOS .app bundle only ever falls back to the generic '/usr/share/locale/' path, so every bundled translation is silently lost regardless of how many languages are compiled into Contents/locale/ -- confirmed on a fresh build of current master with all 61 languages compiled and copied into place: the running app still defaulted to en/C locale, logging 'no compiled translation for language X' for every single one.

The cause: locale_dir resolution checks for a 'locale' directory next to the executable (an AppImage-style layout), but in the .app bundle bleachbit_exe_path is Contents/Resources (the parent of the bleachbit package directory), one level below the real Contents/locale directory, so that check fails and falls through to the system-wide fallback instead.

Not sure whether this is a known limitation and translations are deliberately left out of macOS builds until some later stage -- happy to close this if so. If not, this adds a macOS-specific check for the bundle-relative path, extracting the whole resolution into a small pure function, _resolve_locale_dir(), so the platform-specific branching can be tested directly.

tests/TestCommon.py adds ResolveLocaleDirTestCase with four tests, each confirmed to fail with an ImportError against the pre-fix code before being finalized.