### PR TITLE
Mac.py: read AppleLocale from .GlobalPreferences.plist instead of she…

### DIFF
--- a/bleachbit/Mac.py
+++ b/bleachbit/Mac.py
@@ -12,6 +12,7 @@ import errno
 import logging
 import os
 import platform
+import plistlib
 import subprocess
 from pathlib import Path
 
@@ -57,16 +58,30 @@ MACOSX_DICT_MODERN = {
 }
 
 
-def get_macos_locale():
-    """Return the user's preferred locale on macOS, e.g. 'es_ES'.
+def _read_global_preferences_plist():
+    """Return the parsed contents of ~/Library/Preferences/
+    .GlobalPreferences.plist, or None if it cannot be read."""
+    path = os.path.expanduser(
+        '~/Library/Preferences/.GlobalPreferences.plist')
+    try:
+        with open(path, 'rb') as f:
+            return plistlib.load(f)
+    except (OSError, ValueError, plistlib.InvalidFileException) as e:
+        logger.debug('failed to read %s: %s', path, e)
+        return None
 
-    On macOS, locale.getlocale() reflects POSIX environment variables
-    (LANG/LC_ALL), which are not set when the app is launched from
-    Finder (as opposed to a terminal) and can be stale or inconsistent
-    with the user's actual System Settings > General > Language & Region
-    preference. AppleLocale, read via `defaults read -g AppleLocale`,
-    reflects the real system preference regardless of how the app was
-    launched.
+
+def _get_apple_locale_via_defaults():
+    """Return AppleLocale by shelling out to `defaults read -g
+    AppleLocale`, or None on any failure.
+
+    This is the fallback path: reliable when tested from a terminal,
+    but observed to consistently fail (falling through to the 'C'
+    locale) when the app is launched via an actual Finder double-click
+    rather than a terminal or `open` -- `_read_global_preferences_plist`
+    above does not depend on spawning a subprocess at all, so it is
+    unaffected by whatever session/TCC context differs between those
+    two launch paths, and is tried first.
     """
     try:
         result = subprocess.run(
@@ -79,6 +94,37 @@ def get_macos_locale():
     if result.returncode != 0:
         return None
     value = result.stdout.strip()
+    return value or None
+
+
+def get_macos_locale():
+    """Return the user's preferred locale on macOS, e.g. 'es_ES'.
+
+    On macOS, locale.getlocale() reflects POSIX environment variables
+    (LANG/LC_ALL), which are not set when the app is launched from
+    Finder (as opposed to a terminal) and can be stale or inconsistent
+    with the user's actual System Settings > General > Language & Region
+    preference. AppleLocale reflects the real system preference
+    regardless of how the app was launched.
+
+    Prefer reading it directly from .GlobalPreferences.plist (pure file
+    I/O, no subprocess); fall back to `defaults read -g AppleLocale`,
+    and finally to the first entry of AppleLanguages, if that fails.
+    """
+    value = None
+    prefs = _read_global_preferences_plist()
+    if prefs is not None:
+        value = prefs.get('AppleLocale')
+        if not value:
+            languages = prefs.get('AppleLanguages')
+            if languages:
+                # AppleLanguages uses hyphens ('es-ES'); AppleLocale and
+                # everywhere else in this codebase use underscores.
+                value = languages[0].replace('-', '_')
+
+    if not value:
+        value = _get_apple_locale_via_defaults()
+
     if not value:
         return None
     # AppleLocale can include a variant suffix like 'es_ES@currency=EUR'.

--- a/bleachbit/Mac.py
+++ b/bleachbit/Mac.py
@@ -14,6 +14,7 @@ import os
 import platform
 import plistlib
 import subprocess
+import xml.parsers.expat
 from pathlib import Path
 
 from bleachbit import APP_NAME, FileUtilities, IS_MAC
@@ -66,7 +67,8 @@ def _read_global_preferences_plist():
     try:
         with open(path, 'rb') as f:
             return plistlib.load(f)
-    except (OSError, ValueError, plistlib.InvalidFileException) as e:
+    except (OSError, ValueError, plistlib.InvalidFileException,
+            xml.parsers.expat.ExpatError) as e:
         logger.debug('failed to read %s: %s', path, e)
         return None
 
@@ -107,9 +109,11 @@ def get_macos_locale():
     preference. AppleLocale reflects the real system preference
     regardless of how the app was launched.
 
-    Prefer reading it directly from .GlobalPreferences.plist (pure file
-    I/O, no subprocess); fall back to `defaults read -g AppleLocale`,
-    and finally to the first entry of AppleLanguages, if that fails.
+    Prefer reading AppleLocale directly from .GlobalPreferences.plist
+    (pure file I/O, no subprocess); if AppleLocale is absent from the
+    plist, fall back to the first entry of AppleLanguages in the same
+    plist, and finally to `defaults read -g AppleLocale` if the plist
+    itself cannot be read.
     """
     value = None
     prefs = _read_global_preferences_plist()

--- a/tests/TestMac.py
+++ b/tests/TestMac.py
@@ -133,19 +133,66 @@ class MacTestCase(common.BleachbitTestCase):
             self.assertNotIn('@', ret)
 
     @common.skipUnlessMac
-    def test_get_macos_locale_mocked(self):
-        """get_macos_locale() parses AppleLocale output and strips variants."""
+    def test_get_macos_locale_prefers_plist_apple_locale(self):
+        """get_macos_locale() reads AppleLocale from
+        .GlobalPreferences.plist directly (no subprocess) when
+        available, and strips any variant suffix."""
+        with mock.patch(
+                'bleachbit.Mac._read_global_preferences_plist',
+                return_value={'AppleLocale': 'es_ES@currency=EUR'}), \
+                mock.patch('subprocess.run') as mock_run:
+            self.assertEqual(get_macos_locale(), 'es_ES')
+        mock_run.assert_not_called()
+
+    @common.skipUnlessMac
+    def test_get_macos_locale_falls_back_to_apple_languages(self):
+        """When the plist has no AppleLocale, fall back to the first
+        entry of AppleLanguages, converting its hyphen to the
+        underscore used everywhere else in this codebase."""
+        with mock.patch(
+                'bleachbit.Mac._read_global_preferences_plist',
+                return_value={'AppleLanguages': ['fr-FR', 'en-US']}), \
+                mock.patch('subprocess.run') as mock_run:
+            self.assertEqual(get_macos_locale(), 'fr_FR')
+        mock_run.assert_not_called()
+
+    @common.skipUnlessMac
+    def test_get_macos_locale_falls_back_to_defaults_command(self):
+        """When the plist cannot be read at all, fall back to
+        `defaults read -g AppleLocale`."""
         proc_mock = mock.Mock()
         proc_mock.returncode = 0
         proc_mock.stdout = 'es_ES@currency=EUR\n'
-        with mock.patch('subprocess.run', return_value=proc_mock):
+        with mock.patch(
+                'bleachbit.Mac._read_global_preferences_plist',
+                return_value=None), \
+                mock.patch('subprocess.run', return_value=proc_mock):
             self.assertEqual(get_macos_locale(), 'es_ES')
 
         proc_mock.stdout = ''
-        with mock.patch('subprocess.run', return_value=proc_mock):
+        with mock.patch(
+                'bleachbit.Mac._read_global_preferences_plist',
+                return_value=None), \
+                mock.patch('subprocess.run', return_value=proc_mock):
             self.assertIsNone(get_macos_locale())
 
-        with mock.patch('subprocess.run', side_effect=subprocess.SubprocessError):
+        with mock.patch(
+                'bleachbit.Mac._read_global_preferences_plist',
+                return_value=None), \
+                mock.patch('subprocess.run',
+                          side_effect=subprocess.SubprocessError):
+            self.assertIsNone(get_macos_locale())
+
+    @common.skipUnlessMac
+    def test_get_macos_locale_returns_none_when_all_sources_fail(self):
+        """When both the plist and the defaults command yield
+        nothing, return None rather than an empty string."""
+        with mock.patch(
+                'bleachbit.Mac._read_global_preferences_plist',
+                return_value={}), \
+                mock.patch('subprocess.run') as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = ''
             self.assertIsNone(get_macos_locale())
 
     def test_macos_version_name(self):


### PR DESCRIPTION
…lling out

get_macos_locale() called `defaults read -g AppleLocale` as a subprocess -- reliable when the app was launched from a terminal (or via `open`, even without any arguments), but confirmed to consistently fail with 'no default locale found. Assuming C' when the exact same .app bundle was launched via a genuine Finder double-click instead, with no other change: same files, same bleachbit.ini, same machine, only the launch method differed.

Manually forcing a specific language always worked correctly regardless of launch method, isolating the failure to this one function specifically, not to translation loading in general.

Reading ~/Library/Preferences/.GlobalPreferences.plist directly via plistlib is pure file I/O with no subprocess involved, so it cannot be affected by whatever session/TCC context differs between a terminal-descended process and a genuine Finder-launched one. Confirmed by hand: after applying this fix to the running .app, auto-detect correctly resolved to es_ES on every subsequent real Finder double-click, including immediately after toggling 'Auto-detect language' back on in Preferences without even restarting the app.

The existing `defaults read -g AppleLocale` call is kept as a fallback for the (currently unobserved, but plausible) case where the plist itself cannot be read, with AppleLanguages as a further fallback if AppleLocale specifically is absent from the plist.

tests/TestMac.py replaces test_get_macos_locale_mocked (which directly mocked subprocess.run, no longer reachable in the common case now that the plist read succeeds first on any real machine) with four tests covering the plist-success path, the AppleLanguages fallback, the defaults-command fallback when the plist is unreadable, and the all-sources-fail case.