### PR TITLE
GuiWindow.py: fix on_quit() losing pending option changes

### DIFF
--- a/bleachbit/GuiWindow.py
+++ b/bleachbit/GuiWindow.py
@@ -457,7 +457,14 @@ class GUI(Gtk.ApplicationWindow):
         return False
 
     def on_quit(self, *_args):
-        """Quit the application, used with CTRL+Q or CTRL+W"""
+        """Quit the application, used with CTRL+Q, CTRL+W, or Cmd+Q on macOS"""
+        # Unlike closing via the window's own close button (which fires
+        # delete-event -> on_delete_event() -> options.close()), calling
+        # Gtk.main_quit() directly here never emits delete-event, so any
+        # setting change still waiting on the delayed flush timer
+        # (see Options.__schedule_flush) would otherwise be lost if the
+        # process exits before that timer fires.
+        options.close()
         if Gtk.main_level() > 0:
             Gtk.main_quit()
         else:

--- a/tests/TestGUI.py
+++ b/tests/TestGUI.py
@@ -649,3 +649,23 @@ class GUITestCase(common.BleachbitTestCase):
 
         self.assertFalse(model[parent_iter][1],
                          "Parent should remain unchecked when all children are blocked by expert mode")
+
+    def test_on_quit_commits_pending_options(self):
+        """Regression test: quitting via on_quit() (Ctrl+Q/Ctrl+W, and
+        Cmd+Q on macOS) must flush pending option changes to disk, the
+        same way closing the window via its own close button does
+        through on_delete_event() -> options.close().
+
+        Before the fix, on_quit() called Gtk.main_quit()/self.destroy()
+        directly without ever emitting delete-event, so a setting
+        change still waiting on the delayed flush timer
+        (Options.__schedule_flush) would be lost if the process exited
+        via this path before that timer fired.
+        """
+        with mock.patch('bleachbit.GuiWindow.options.close') as mock_close, \
+                mock.patch('bleachbit.GuiWindow.Gtk.main_level', return_value=1), \
+                mock.patch('bleachbit.GuiWindow.Gtk.main_quit') as mock_main_quit:
+            self.app._window.on_quit()
+
+        mock_close.assert_called_once()
+        mock_main_quit.assert_called_once()


### PR DESCRIPTION
on_quit() (bound to Ctrl+Q/Ctrl+W on all platforms, and to Cmd+Q on macOS via the direct key-press-event handler added for it) calls Gtk.main_quit()/self.destroy() directly, which never emits delete-event -- unlike closing the window via its own close button, which fires delete-event -> on_delete_event() -> options.close().

Options.set() defers the actual write to disk via a delayed flush timer (__schedule_flush); if the process exits through on_quit() before that timer fires, any pending change is lost even though it appeared to take effect immediately in the running session.

Confirmed by hand: toggled 'Auto-detect language' in Preferences, quit via Cmd+Q, reopened the app, and found the checkbox back to its previous state -- while quitting via the window's own close button correctly persisted the same change.

This predates the macOS Cmd+Q fix (Ctrl+Q/Ctrl+W were already bound to the same on_quit() on every platform beforehand), but Cmd+Q being the overwhelmingly standard way to quit an application on macOS specifically -- rather than clicking the window's own close button, as is more common on Linux/Windows -- makes this considerably more consequential there.

tests/TestGUI.py adds test_on_quit_commits_pending_options, confirmed to fail (options.close() never called) against the pre-fix code before being finalized.