### PR TITLE
Fix hamburger menu not following language changes on macOS

### DIFF
--- a/bleachbit/GuiWindow.py
+++ b/bleachbit/GuiWindow.py
@@ -1023,6 +1023,13 @@ class GUI(Gtk.ApplicationWindow):
 
     def update_headerbar_labels(self):
         """Update the labels and tooltips in the headerbar buttons"""
+        # The hamburger menu is not just a label -- it's a whole
+        # Gtk.Builder-loaded Gio.MenuModel that only picks up a
+        # language change if explicitly reloaded (see the comment in
+        # _reload_app_menu()).
+        if hasattr(self, 'menu_button'):
+            self._reload_app_menu()
+
         # Preview button
         self.preview_button.set_label(PREVIEW_MSG)
         self.preview_button.set_tooltip_text(
@@ -1138,22 +1145,41 @@ class GUI(Gtk.ApplicationWindow):
         hbar.pack_start(box)
 
         # Add hamburger menu on the right
-        menu_button = Gtk.MenuButton()
-        icon = Gio.ThemedIcon(name="open-menu-symbolic")
-        image = Gtk.Image.new_from_gicon(icon, Gtk.IconSize.BUTTON)
-        builder = Gtk.Builder()
+        self.menu_button = Gtk.MenuButton()
         app_menu_path = bleachbit.get_share_path('app-menu.ui')
         if app_menu_path:
-            builder.add_from_file(app_menu_path)
-            menu_button.set_menu_model(builder.get_object('app-menu'))
-            menu_button.add(image)
-            hbar.pack_end(menu_button)
+            icon = Gio.ThemedIcon(name="open-menu-symbolic")
+            image = Gtk.Image.new_from_gicon(icon, Gtk.IconSize.BUTTON)
+            self._reload_app_menu(app_menu_path)
+            self.menu_button.add(image)
+            hbar.pack_end(self.menu_button)
         else:
             hbar.pack_end(Gtk.Label('error: app-menu.ui not found'))
 
         # Update all labels and tooltips
         self.update_headerbar_labels()
         return hbar
+
+    def _reload_app_menu(self, app_menu_path=None):
+        """(Re)load app-menu.ui into self.menu_button.
+
+        Gtk.Builder translates the .ui file's own translatable strings
+        via the C locale set by locale.setlocale() (see the comment in
+        Language.setup_translation()), baked in at load time -- unlike
+        the rest of the headerbar, which re-reads its labels through
+        Python's own gettext calls on every call to
+        update_headerbar_labels() and so picks up a later language
+        change immediately, a Gtk.Builder-loaded menu stays frozen in
+        whatever language was active the one time it was originally
+        loaded unless it is explicitly reloaded like this.
+        """
+        if app_menu_path is None:
+            app_menu_path = bleachbit.get_share_path('app-menu.ui')
+        if not app_menu_path:
+            return
+        builder = Gtk.Builder()
+        builder.add_from_file(app_menu_path)
+        self.menu_button.set_menu_model(builder.get_object('app-menu'))
 
     def on_configure_event(self, _widget, _event):
         (x, y) = self.get_position()

--- a/bleachbit/Language.py
+++ b/bleachbit/Language.py
@@ -372,6 +372,35 @@ def setup_translation():
     assert isinstance(locale_dir, str), f"locale_dir: {locale_dir}"
     if IS_WINDOWS and user_locale:
         os.environ['LANG'] = user_locale
+    elif IS_POSIX and user_locale:
+        # GLib's own g_get_language_names() (used by Gtk.Builder to
+        # translate .ui files like the hamburger menu) reads LANGUAGE
+        # directly from the environment with top priority -- it does
+        # not consult locale.setlocale()'s C-level locale state at
+        # all, so without this, a Gtk.Builder-loaded menu stays frozen
+        # in whatever locale the OS environment happened to have at
+        # process launch (e.g. always the real macOS AppleLocale
+        # preference), never following a later in-app language change.
+        # Confirmed by hand: without setting this, the app-menu.ui
+        # hamburger menu stayed in Spanish through three different
+        # manually-selected languages and a full app restart, on a
+        # machine whose real System Settings > Language is Spanish;
+        # setting it here made it follow the selected language
+        # immediately.
+        #
+        # Only LANGUAGE is set, deliberately not LANG/LC_ALL: LANGUAGE
+        # is a GNU gettext-specific extension used purely as a
+        # translation-priority hint and has no effect on the process's
+        # actual C locale/encoding, whereas LANG/LC_ALL are read by
+        # every other locale-aware consumer in the process, including
+        # any subprocess spawned afterward -- and a bare code without
+        # an explicit encoding (which GLib's own parsing of these
+        # variables specifically requires; a '.UTF-8' suffix breaks it,
+        # verified by hand) crashed a subprocess Python interpreter
+        # started later with 'Fatal Python error:
+        # config_get_locale_encoding: ... nl_langinfo(CODESET) failed'
+        # when this was tried with LANG/LC_ALL instead.
+        os.environ['LANGUAGE'] = user_locale
     text_domain = 'bleachbit'
     try:
         t = gettext.translation(

--- a/tests/TestLanguage.py
+++ b/tests/TestLanguage.py
@@ -19,6 +19,7 @@
 
 
 import locale
+import os
 import unittest
 from unittest import mock
 
@@ -138,3 +139,101 @@ class LanguageTestCase(common.BleachbitTestCase):
                           log_context.output[0])
 
         self.assertIn(result, [locale.getlocale()[0], 'C', 'en', 'en_US'])
+
+
+class SetupTranslationEnvironTestCase(common.BleachbitTestCase):
+    """Test case for the LANGUAGE environment variable side effect
+    of setup_translation()"""
+
+    def setUp(self):
+        super().setUp()
+        self._language_env_backup = os.environ.get('LANGUAGE')
+        # setup_translation() reassigns this plain module-level
+        # global (used by every _()/get_text() call throughout the
+        # whole codebase) as a real side effect of calling the real
+        # gettext.translation() -- mocking that call prevents the
+        # reassignment in the first place, but capture/restore the
+        # global directly too as a second line of defense, since
+        # this specific global is the actual, confirmed mechanism by
+        # which an earlier, less careful version of this same test
+        # leaked a real Italian translation into unrelated later
+        # tests' own log messages for the rest of the test process.
+        from bleachbit import Language as _language_module
+        self._t_backup = _language_module.t
+
+    def tearDown(self):
+        from bleachbit import Language as _language_module
+        _language_module.t = self._t_backup
+        if self._language_env_backup is None:
+            os.environ.pop('LANGUAGE', None)
+        else:
+            os.environ['LANGUAGE'] = self._language_env_backup
+        super().tearDown()
+
+    def test_setup_translation_sets_language_env_on_posix(self):
+        """Regression test: GLib's g_get_language_names(), used
+        by Gtk.Builder to translate .ui files such as the hamburger
+        menu, reads LANGUAGE directly from the environment with
+        top priority -- it does not consult locale.setlocale()'s C
+        locale state at all, so without setting it, a
+        Gtk.Builder-loaded menu stays frozen in whatever locale
+        was in the environment at process launch (e.g. the real
+        macOS AppleLocale system preference), never following a
+        later in-app language change.
+
+        Confirmed by hand on the real .app: without this, the
+        hamburger menu stayed in Spanish through three different
+        manually-selected languages and a full app restart, on a
+        machine whose real System Settings > Language is Spanish;
+        setting LANGUAGE made it follow the selected language
+        immediately, without even restarting the app.
+
+        Only LANGUAGE is checked here, deliberately not LANG/
+        LC_ALL: an earlier version of this fix also set those,
+        which crashed a subprocess Python interpreter started
+        later with 'Fatal Python error:
+        config_get_locale_encoding: ... nl_langinfo(CODESET)
+        failed', since a bare code without an explicit encoding
+        (required for GLib's own parsing of these variables
+        specifically -- a '.UTF-8' suffix breaks it, verified by
+        hand) is not a well-formed LC_ALL/LANG value for every
+        other locale-aware consumer in the process.
+        """
+        os.environ.pop('LANGUAGE', None)
+        with mock.patch('bleachbit.Language.get_active_language_code',
+                        return_value='it_IT'), \
+                mock.patch('bleachbit.Language.IS_POSIX', True), \
+                mock.patch('bleachbit.Language.IS_WINDOWS', False), \
+                mock.patch('locale.setlocale'), \
+                mock.patch('gettext.translation'):
+            setup_translation()
+        self.assertEqual(os.environ.get('LANGUAGE'), 'it_IT')
+
+    def test_setup_translation_does_not_set_lang_or_lc_all_on_posix(self):
+        """LANG/LC_ALL must be left untouched on POSIX -- see the
+        comment in setup_translation() and in the test above for
+        why setting them crashed a subprocess Python interpreter.
+        """
+        lang_backup = os.environ.get('LANG')
+        lc_all_backup = os.environ.get('LC_ALL')
+        try:
+            os.environ.pop('LANG', None)
+            os.environ.pop('LC_ALL', None)
+            with mock.patch('bleachbit.Language.get_active_language_code',
+                            return_value='es_ES'), \
+                    mock.patch('bleachbit.Language.IS_POSIX', True), \
+                    mock.patch('bleachbit.Language.IS_WINDOWS', False), \
+                    mock.patch('locale.setlocale'), \
+                    mock.patch('gettext.translation'):
+                setup_translation()
+            self.assertIsNone(os.environ.get('LANG'))
+            self.assertIsNone(os.environ.get('LC_ALL'))
+        finally:
+            if lang_backup is None:
+                os.environ.pop('LANG', None)
+            else:
+                os.environ['LANG'] = lang_backup
+            if lc_all_backup is None:
+                os.environ.pop('LC_ALL', None)
+            else:
+                os.environ['LC_ALL'] = lc_all_backup


### PR DESCRIPTION
Two separate bugs combined to freeze the hamburger menu (app-menu.ui, loaded via Gtk.Builder) in whatever language was active at process launch, regardless of any later language change made in Preferences, with or without restarting the app:

1. GuiWindow.py: create_headerbar() loaded app-menu.ui into the menu button exactly once, at initial window construction. Unlike the rest of the headerbar (whose labels/tooltips are re-set through Python's own gettext _() calls on every update_headerbar_labels()), Gtk.Builder translates a .ui file's own translatable strings once, at load time, with no later re-evaluation -- so the menu stayed permanently frozen in whichever language was active the one time it was ever built.

   Extracts the loading logic into _reload_app_menu(), storing the button as self.menu_button, and calls it again from update_headerbar_labels() (already invoked on every language change) so the menu is rebuilt, not just its surrounding labels.

2. Language.py: even with the menu correctly reloading, it still stayed in Spanish through three different manually-selected languages and a full app restart, on a machine whose real macOS System Settings > Language is Spanish. GLib's own g_get_language_names() (which Gtk.Builder uses for a .ui file's translations) reads the LANGUAGE/LC_ALL/LC_MESSAGES/LANG environment variables directly -- it does not consult locale.setlocale()'s C locale state at all, which is the only thing setup_translation() was setting on POSIX. Without LANGUAGE ever actually being set in the environment, GLib fell back to whatever the real OS environment had at launch (the real AppleLocale preference), completely bypassing BleachBit's own in-app language selection.

   setup_translation() now also sets os.environ['LANGUAGE'] on POSIX (mirroring the existing Windows-only os.environ['LANG'] line). Deliberately only LANGUAGE, not LANG/LC_ALL: those are read by every other locale-aware consumer in the process, including any subprocess spawned afterward, and a bare code without an explicit encoding (required for GLib's own parsing of these variables specifically -- confirmed by hand that a '.UTF-8' suffix breaks it) is not a well-formed LC_ALL/LANG value elsewhere, and setting them this way was confirmed by hand to crash a subprocess Python interpreter started later with 'Fatal Python error: config_get_locale_encoding: ... nl_langinfo(CODESET) failed'.

Confirmed by hand on the real .app via a genuine Finder double-click: before, the menu stayed in Spanish through English, French, and German selections and a full restart; after, it correctly switches immediately on every language change, without even restarting the app.

tests/TestLanguage.py adds SetupTranslationEnvironTestCase with two tests, confirmed to fail against the pre-fix code before being finalized. Both mock gettext.translation() and locale.setlocale() (and directly snapshot/restore the module-level Language.t): the real setup_translation() has these two further real side effects beyond the one each test is targeting, and leaving either unmocked was confirmed by hand to leak a non-English translation into unrelated later tests' own log messages for the rest of the test process.