### PR TITLE
GuiPreferences.py: fix language combo box showing nothing selected

### DIFF
--- a/bleachbit/GuiPreferences.py
+++ b/bleachbit/GuiPreferences.py
@@ -362,12 +362,22 @@ class PreferencesDialog:
             lang_items = [('en_us', 'English')]
         else:
             lang_items = supported_langs.items()
+        # current_lang_code may be a region-specific code like 'es_ES'
+        # (e.g. from macOS AppleLocale), while lang_items' keys are the
+        # bare base codes BleachBit ships translations under (e.g.
+        # 'es') -- matching only the base part before the underscore
+        # keeps the combo box in sync with the language actually in
+        # use instead of leaving nothing selected.
+        current_lang_base = current_lang_code.split(
+            '_')[0] if current_lang_code else None
         for lang_idx, (lang_code, native) in enumerate(lang_items):
             if native:
                 self.lang_combo.append_text(f"{native} ({lang_code})")
             else:
                 self.lang_combo.append_text(lang_code)
             if lang_code == current_lang_code:
+                active_language_idx = lang_idx
+            elif active_language_idx is None and lang_code == current_lang_base:
                 active_language_idx = lang_idx
         if active_language_idx is not None:
             self.lang_combo.set_active(active_language_idx)

--- a/tests/TestGUI.py
+++ b/tests/TestGUI.py
@@ -238,6 +238,23 @@ class GUITestCase(common.BleachbitTestCase):
         self.assertEqual(mock_get.call_count, 1)
         pref.dialog.destroy()
 
+    def test_preferences_language_combo_matches_region_specific_code(self):
+        """Regression test: when the active language code is
+        region-specific (e.g. 'es_ES', as returned by macOS's
+        AppleLocale-based auto-detection), the language combo box must
+        still show it as selected, matching against the base code
+        ('es') that BleachBit's own supported-language list uses --
+        not leave nothing selected because 'es_ES' != 'es'."""
+        with mock.patch('bleachbit.GuiPreferences.get_active_language_code',
+                        return_value='es_ES'):
+            pref = self.app.get_preferences_dialog()
+        try:
+            active_text = pref.lang_combo.get_active_text()
+            self.assertIsNotNone(active_text)
+            self.assertIn('(es)', active_text)
+        finally:
+            pref.dialog.destroy()
+
     def test_preferences_cookies_page(self):
         """Opens the preferences dialog and navigates to cookies page"""
         pref = self.app.get_preferences_dialog()


### PR DESCRIPTION
The language dropdown in Preferences compared each supported language's code against the active language code with strict string equality. BleachBit's own supported-language list uses bare base codes ('es', 'fr'), but get_active_language_code() can return a region-specific code ('es_ES') -- notably on macOS, where AppleLocale-based auto-detection (get_macos_locale()) always returns one. 'es' == 'es_ES' is false, so no entry ever matched and the combo box was left showing nothing selected, even though the app itself was correctly running in that language.

Falls back to comparing against the base code (the part before the first underscore) when no exact match is found, so a region-specific active language still highlights its corresponding entry.

Confirmed by hand on the real .app via a genuine Finder double-click: the box previously showed nothing with 'Auto-detect language' checked and es_ES active; now shows 'Español (es)' correctly selected.

tests/TestGUI.py adds test_preferences_language_combo_matches_region_specific_code, confirmed to fail (no active text in the combo) against the pre-fix code before being finalized.