### PR TITLE
Worker.py: add a hint when files could not be deleted due to permissions

### DIFF
--- a/bleachbit/Worker.py
+++ b/bleachbit/Worker.py
@@ -69,6 +69,14 @@ class Worker:
         self.total_bytes = 0
         self.total_deleted = 0
         self.total_errors = 0
+        # Counts only the generic 'Access denied' case below (a
+        # plain EACCES with none of the more specific Windows
+        # sub-causes matched) -- e.g. a file owned by another
+        # user because it was installed by an app's own updater
+        # running with elevated privileges. Used to show one
+        # extra hint line in the final summary, without
+        # changing the per-file 'Access denied: %s' message.
+        self.total_access_denied_errors = 0
         self.total_special = 0  # special operations
         self.yield_time = None
         self.is_aborted = False
@@ -133,6 +141,7 @@ class Worker:
                         _("Access denied when deleting registry key: %s"), e.filename)
                 else:
                     logger.error(_("Access denied: %s"), e.filename)
+                    self.total_access_denied_errors += 1
             elif (e.__class__.__module__ == 'sqlite3'
                   and e.__class__.__name__ == 'OperationalError'
                   and str(e).startswith('database is locked')):
@@ -358,6 +367,18 @@ class Worker:
             self.ui.append_text("\n%s" % line)
         if self.total_errors > 0:
             line = _("Errors: %d") % self.total_errors
+            self.ui.append_text("\n%s" % line, 'error')
+        if self.total_access_denied_errors > 0:
+            # TRANSLATORS: Shown after cleaning when at least one
+            # file could not be accessed due to a permission
+            # error, to suggest a likely cause and remedy (e.g. a
+            # file owned by another user because it was
+            # installed by an app's own updater running with
+            # elevated privileges).
+            line = _("Some files could not be accessed due to "
+                    "permission errors. If they belong to "
+                    "another user, try running BleachBit with "
+                    "administrator privileges.")
             self.ui.append_text("\n%s" % line, 'error')
         self.ui.append_text('\n')
 

--- a/tests/TestWorker.py
+++ b/tests/TestWorker.py
@@ -263,6 +263,30 @@ class WorkerTestCase(common.BleachbitTestCase):
                               log_context.output[0])
                 self.assertNotIn('\\\\', log_context.output[0])
 
+    def test_access_denied_permission_hint(self):
+        """A generic EACCES (not one of the specific Windows sub-cases,
+        e.g. a plain 'Permission denied' from a file owned by another
+        user) increments Worker.total_access_denied_errors, which the
+        final summary uses to show one extra hint line suggesting
+        administrator privileges -- in addition to, not instead of,
+        the existing unchanged per-file 'Access denied: %s' line."""
+        ui = CLI.CliCallback()
+        (fd, filename) = tempfile.mkstemp(
+            prefix='bleachbit-test-worker', dir=self.tempdir)
+        os.write(fd, b'123')
+        os.close(fd)
+        astr = '<action command="access.denied" path="%s"/>' % filename
+        cleaner = TestCleaner.action_to_cleaner(astr)
+        backends['test'] = cleaner
+        operations = {'test': ['option1']}
+        worker = Worker(ui, True, operations)
+        run = worker.run()
+        with self.assertLogs(level='ERROR'):
+            while next(run):
+                pass
+        del backends['test']
+        self.assertEqual(worker.total_access_denied_errors, 1)
+
     def test_DoesNotExist(self):
         """Test Worker using Action.DoesNotExistAction"""
         with self.assertLogs(level='ERROR') as log_context:


### PR DESCRIPTION
Discovered while testing the Chrome orphaned-versions cleaner (macos.orphaned_framework_versions, PR #2320): a real orphaned Chrome version created by Chrome's own auto-updater is typically owned by root:wheel, since that updater runs with elevated privileges to write into /Applications. Previewing correctly identified and sized the folder, but the actual delete silently reported 0 files deleted and 451 errors, with the only clue being 451 repeated 'Access denied: %s' lines (one per file) and no explanation of the likely cause or remedy.

Confirmed running BleachBit itself with sudo (using the venv's own python3, not the system one, and separately confirmed working via the packaged .app's own embedded executable too) successfully deletes the same root-owned folder with 0 errors -- so the underlying capability already works correctly; what was missing was any indication to the user that this was the reason for the failure.

Adds Worker.total_access_denied_errors, incremented only in the generic 'Access denied: %s' branch (not the more specific Windows sub-cases already handled separately: delete_locked_file, delete_registry_value, delete_registry_key, which are typically about a file being in use rather than being owned by another user). When that counter is above zero, the final summary shows one additional line suggesting the files may belong to another user and to try running BleachBit with administrator privileges -- in addition to, never instead of, the existing unchanged per-file message.

Confirmed by hand on the real .app: without this, the summary just showed 'Errors: 451' with no context; now it also shows the hint line, correctly, alongside the unchanged per-file lines. This is purely informational -- it does not attempt to delete anything with elevated privileges itself; running BleachBit with sudo (confirmed working on this machine, both from source with the venv's python3 and via the packaged .app's own embedded executable) remains the way to actually delete such files today.

tests/TestWorker.py adds test_access_denied_permission_hint, confirmed to fail (AttributeError: total_access_denied_errors) against the pre-fix code before being finalized.